### PR TITLE
Make ClientCapabilities.experimental field optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "languageserver-types"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Bruno Medeiros <bruno.do.medeiros@gmail.com>"]
 
 description = "Types for interaction with a language server, using VSCode's Language Server Protocol"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,7 +771,7 @@ pub struct ClientCapabilities {
     /**
 	 * Experimental client capabilities.
 	 */
-    pub experimental: Value,
+    pub experimental: Option<Value>,
 }
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize)]


### PR DESCRIPTION
Closes #14, and should allow RLS to fix rust-lang-nursery/rls#312.