### PR TITLE
fix: Allow the InitializeParams::rootUri to be missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "languageserver-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Bruno Medeiros <bruno.do.medeiros@gmail.com>"]
 
 description = "Types for interaction with a language server, using VSCode's Language Server Protocol"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,6 +498,7 @@ pub struct InitializeParams {
     /// `rootUri` wins.
     #[serde(with="option_url")]
     #[serde(rename="rootUri")]
+    #[serde(default)]
     pub root_uri: Option<Url>,
 
     /// User provided initialization options.
@@ -2274,5 +2275,10 @@ mod tests {
                                         .collect(),
                             },
                            r#"{"tabSize":123,"insertSpaces":true,"prop":1.0}"#);
+    }
+
+    #[test]
+    fn root_uri_can_be_missing() {
+         serde_json::from_str::<InitializeParams>(r#"{ "capabilities": {} }"#).unwrap();
     }
 }


### PR DESCRIPTION
When using `with` attributes optional fields need to be explicitly
marked as `default` or the deserializer will fail immediately.

https://github.com/serde-rs/serde/issues/259

cc https://github.com/rust-lang-nursery/rls/issues/312