### PR TITLE
Hover contents could be single entry or multiple entries.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1615,11 +1615,21 @@ pub const REQUEST__Hover: &'static str = "textDocument/hover";
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Hover {
     /// The hover's content
-    pub contents: Vec<MarkedString>, // FIXME: need to review if this is correct
-    // contents: MarkedString | MarkedString[];
+    pub contents: HoverContents,
     /// An optional range is a range inside a text document
     /// that is used to visualize a hover, e.g. by changing the background color.
     pub range: Option<Range>,
+}
+
+
+/**
+ * Hover contents could be single entry or multiple entries.
+ */
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum HoverContents {
+    Scalar(MarkedString),
+    Array(Vec<MarkedString>),
 }
 
 /**


### PR DESCRIPTION
https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_hover

This is a breaking change. Might need to upgrade version number as well. Just not sure which part of version should bump.