### PR TITLE
Implement Ord for Position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub struct CancelParams {
 
 /// Position in a text document expressed as zero-based line and character offset.
 /// A position is between two characters like an 'insert' cursor in a editor.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default, Deserialize, Serialize)]
 pub struct Position {
     /// Line position in a document (zero-based).
     pub line: u64,


### PR DESCRIPTION
The Position type has a sensible ordering, first by line then by character. This PR implements PartialOrd and Ord for Position. Because Ord requires Eq, this PR requires https://github.com/gluon-lang/languageserver-types/pull/27.