### PR TITLE
Message traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,6 +504,15 @@ pub type DocumentSelector = Vec<DocumentFilter>;
  * notifications should be dropped.
 
 */
+#[derive(Debug)]
+pub struct Initialize;
+
+impl Request for Initialize {
+    type Params = InitializeParams;
+    type Result = InitializeResult;
+    const METHOD: &'static str = REQUEST__Initialize;
+}
+
 pub const REQUEST__Initialize: &'static str = "initialize";
 
 /// The initialized notification is sent from the client to the server after the client received
@@ -519,7 +528,6 @@ impl Notification for Initialized {
 }
 
 pub const NOTIFICATION__Initialized: &'static str = "initialized";
-
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct InitializeParams {
@@ -1013,6 +1021,15 @@ pub struct ServerCapabilities {
  * but to not exit (otherwise the response might not be delivered correctly to the client).
  * There is a separate exit notification that asks the server to exit.
  */
+#[derive(Debug)]
+pub struct Shutdown;
+
+impl Request for Shutdown {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = REQUEST__Shutdown;
+}
+
 pub const REQUEST__Shutdown: &'static str = "shutdown";
 
 /**
@@ -1029,7 +1046,6 @@ impl Notification for Exit {
 }
 
 pub const NOTIFICATION__Exit: &'static str = "exit";
-
 
 /**
  * The show message notification is sent from a server to a client to ask the client to display a particular message
@@ -1101,6 +1117,15 @@ impl serde::Serialize for MessageType {
  * in the user interface. In addition to the show message notification the request allows to pass actions and to
  * wait for an answer from the client.
  */
+#[derive(Debug)]
+pub struct ShowMessageRequest;
+
+impl Request for ShowMessageRequest {
+    type Params = ShowMessageRequestParams;
+    type Result = Option<MessageActionItem>;
+    const METHOD: &'static str = REQUEST__ShowMessageRequest;
+}
+
 pub const REQUEST__ShowMessageRequest: &'static str = "window/showMessageRequest";
 
 
@@ -1611,8 +1636,23 @@ impl PublishDiagnosticsParams {
  request is sent with the selected completion item as a param. The returned completion item should have the
  documentation property filled in.
 */
-// result: CompletionItem[] | CompletionList FIXME
+#[derive(Debug)]
+pub struct Completion;
+
+impl Request for Completion {
+    type Params = TextDocumentPositionParams; // TODO: extend with CompletionContext as CompletionParams
+    type Result = CompletionResponse;
+    const METHOD: &'static str = REQUEST__Completion;
+}
+
 pub const REQUEST__Completion: &'static str = "textDocument/completion";
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionResponse {
+    Array(Vec<CompletionItem>),
+    List(CompletionList),
+}
 
 /// Represents a collection of [completion items](#CompletionItem) to be presented
 /// in the editor.
@@ -1796,11 +1836,28 @@ impl serde::Serialize for InsertTextFormat {
 }
 
 /// The request is sent from the client to the server to resolve additional information for a given completion item.
-pub const REQUEST__ResolveCompletionItem: &'static str = "completionItem/resolve";
+#[derive(Debug)]
+pub struct ResolveCompletionItem;
 
+impl Request for ResolveCompletionItem {
+    type Params = CompletionItem;
+    type Result = CompletionItem;
+    const METHOD: &'static str = REQUEST__ResolveCompletionItem;
+}
+
+pub const REQUEST__ResolveCompletionItem: &'static str = "completionItem/resolve";
 
 /// The hover request is sent from the client to the server to request hover information at a given text
 /// document position.
+#[derive(Debug)]
+pub struct HoverRequest;
+
+impl Request for HoverRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<Hover>;
+    const METHOD: &'static str = REQUEST__Hover;
+}
+
 pub const REQUEST__Hover: &'static str = "textDocument/hover";
 
 /// The result of a hover request.
@@ -1863,6 +1920,15 @@ impl MarkedString {
 
 /// The signature help request is sent from the client to the server to request signature information at
 /// a given cursor position.
+#[derive(Debug)]
+pub struct SignatureHelpRequest;
+
+impl Request for SignatureHelpRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<SignatureHelp>;
+    const METHOD: &'static str = REQUEST__SignatureHelp;
+}
+
 pub const REQUEST__SignatureHelp: &'static str = "textDocument/signatureHelp";
 
 
@@ -1917,6 +1983,25 @@ pub struct ParameterInformation {
 
 /// The goto definition request is sent from the client to the server to resolve the definition location of
 /// a symbol at a given text document position.
+#[derive(Debug)]
+pub struct GotoDefinition;
+
+impl Request for GotoDefinition {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<GotoDefinitionResponse>;
+    const METHOD: &'static str = REQUEST__GotoDefinition;
+}
+
+/**
+ * GotoDefinition response can be single location or multiple ones.
+ */
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GotoDefinitionResponse {
+    Scalar(Location),
+    Array(Vec<Location>),
+}
+
 pub const REQUEST__GotoDefinition: &'static str = "textDocument/definition";
 
 /// The references request is sent from the client to the server to resolve project-wide references for the
@@ -1954,6 +2039,15 @@ pub struct ReferenceContext {
  Symbol matches usually have a DocumentHighlightKind of Read or Write whereas fuzzy or textual matches
  use Textas the kind.
 */
+#[derive(Debug)]
+pub struct DocumentHighlightRequest;
+
+impl Request for DocumentHighlightRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<Vec<DocumentHighlight>>;
+    const METHOD: &'static str = REQUEST__DocumentHighlight;
+}
+
 pub const REQUEST__DocumentHighlight: &'static str = "textDocument/documentHighlight";
 
 /// A document highlight is a range inside a text document which deserves
@@ -2013,6 +2107,15 @@ impl serde::Serialize for DocumentHighlightKind {
  * The document symbol request is sent from the client to the server to list all symbols found in a given
  * text document.
  */
+#[derive(Debug)]
+pub struct DocumentSymbol;
+
+impl Request for DocumentSymbol {
+    type Params = DocumentSymbolParams;
+    type Result = Option<Vec<SymbolInformation>>;
+    const METHOD: &'static str = REQUEST__DocumentSymbols;
+}
+
 pub const REQUEST__DocumentSymbols: &'static str = "textDocument/documentSymbol";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2095,6 +2198,15 @@ impl serde::Serialize for SymbolKind {
  * The workspace symbol request is sent from the client to the server to list project-wide symbols
  * matching the query string.
  */
+#[derive(Debug)]
+pub struct WorkspaceSymbol;
+
+impl Request for WorkspaceSymbol {
+    type Params = WorkspaceSymbolParams;
+    type Result = Option<Vec<SymbolInformation>>;
+    const METHOD: &'static str = REQUEST__WorkspaceSymbols;
+}
+
 pub const REQUEST__WorkspaceSymbols: &'static str = "workspace/symbol";
 
 /// The parameters of a Workspace Symbol Request.
@@ -2105,6 +2217,14 @@ pub struct WorkspaceSymbolParams {
 }
 
 /// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server. In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request workspace/applyEdit which is sent from the server to the client.
+#[derive(Debug)]
+pub struct ExecuteCommand;
+
+impl Request for ExecuteCommand {
+    type Params = ExecuteCommandParams;
+    type Result = Option<Value>;
+    const METHOD: &'static str = REQUEST__ExecuteCommand;
+}
 
 pub const REQUEST__ExecuteCommand: &'static str = "workspace/executeCommand";
 
@@ -2135,6 +2255,15 @@ pub struct ExecuteCommandRegistrationOptions {
 
 /// The workspace/applyEdit request is sent from the server to the client to modify resource on the
 /// client side.
+#[derive(Debug)]
+pub struct ApplyWorkspaceEdit;
+
+impl Request for ApplyWorkspaceEdit {
+    type Params = ApplyWorkspaceEditParams;
+    type Result = ApplyWorkspaceEditResponse;
+    const METHOD: &'static str = REQUEST__ApplyEdit;
+}
+
 pub const REQUEST__ApplyEdit: &'static str = "workspace/applyEdit";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2158,6 +2287,15 @@ pub struct ApplyWorkspaceEditResponse {
  * and range. The request is triggered when the user moves the cursor into a problem marker in the editor or
  * presses the lightbulb associated with a marker.
  */
+#[derive(Debug)]
+pub struct CodeActionRequest;
+
+impl Request for CodeActionRequest {
+    type Params = CodeActionParams;
+    type Result = Option<Vec<Command>>;
+    const METHOD: &'static str = REQUEST__CodeAction;
+}
+
 pub const REQUEST__CodeAction: &'static str = "textDocument/codeAction";
 
 /// Params for the CodeActionRequest
@@ -2185,6 +2323,15 @@ pub struct CodeActionContext {
 /**
  * The code lens request is sent from the client to the server to compute code lenses for a given text document.
  */
+#[derive(Debug)]
+pub struct CodeLensRequest;
+
+impl Request for CodeLensRequest {
+    type Params = CodeLensParams;
+    type Result = Option<Vec<CodeLens>>;
+    const METHOD: &'static str = REQUEST__CodeLens;
+}
+
 pub const REQUEST__CodeLens: &'static str = "textDocument/codeLens";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2216,14 +2363,31 @@ pub struct CodeLens {
  * The code lens resolve request is sent from the client to the server to resolve the command for a
  * given code lens item.
  */
-pub const REQUEST__CodeLensResolve: &'static str = "codeLens/resolve";
+#[derive(Debug)]
+pub struct CodeLensResolve;
 
+impl Request for CodeLensResolve {
+    type Params = CodeLens;
+    type Result = CodeLens;
+    const METHOD: &'static str = REQUEST__CodeLensResolve;
+}
+
+pub const REQUEST__CodeLensResolve: &'static str = "codeLens/resolve";
 
 /**
 
  The document links request is sent from the client to the server to request the location of links in a document.
 
 */
+#[derive(Debug)]
+pub struct DocumentLinkRequest;
+
+impl Request for DocumentLinkRequest {
+    type Params = DocumentLinkParams;
+    type Result = Option<Vec<DocumentLink>>;
+    const METHOD: &'static str = REQUEST__DocumentLink;
+}
+
 pub const REQUEST__DocumentLink: &'static str = "textDocument/documentLink";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2258,12 +2422,30 @@ pub struct DocumentLink {
  a given document link.
 
 */
+#[derive(Debug)]
+pub struct DocumentLinkResolve;
+
+impl Request for DocumentLinkResolve {
+    type Params = DocumentLink;
+    type Result = DocumentLink;
+    const METHOD: &'static str = REQUEST__DocumentLinkResolve;
+}
+
 pub const REQUEST__DocumentLinkResolve: &'static str = "documentLink/resolve";
 
 
 /**
  * The document formatting request is sent from the server to the client to format a whole document.
  */
+#[derive(Debug)]
+pub struct Formatting;
+
+impl Request for Formatting {
+    type Params = DocumentFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = REQUEST__Formatting;
+}
+
 pub const REQUEST__Formatting: &'static str = "textDocument/formatting";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -2378,6 +2560,15 @@ impl serde::Serialize for FormattingOptions {
 
 
 /// The document range formatting request is sent from the client to the server to format a given range in a document.
+#[derive(Debug)]
+pub struct RangeFormatting;
+
+impl Request for RangeFormatting {
+    type Params = DocumentRangeFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = REQUEST__RangeFormatting;
+}
+
 pub const REQUEST__RangeFormatting: &'static str = "textDocument/rangeFormatting";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -2397,6 +2588,15 @@ pub struct DocumentRangeFormattingParams {
  * The document on type formatting request is sent from the client to the server to format parts of
  * the document during typing.
  */
+#[derive(Debug)]
+pub struct OnTypeFormatting;
+
+impl Request for OnTypeFormatting {
+    type Params = DocumentOnTypeFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = REQUEST__OnTypeFormatting;
+}
+
 pub const REQUEST__OnTypeFormatting: &'static str = "textDocument/onTypeFormatting";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -2441,6 +2641,15 @@ pub struct DocumentOnTypeFormattingRegistrationOptions {
 /**
  * The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
  */
+#[derive(Debug)]
+pub struct Rename;
+
+impl Request for Rename {
+    type Params = RenameParams;
+    type Result = Option<WorkspaceEdit>;
+    const METHOD: &'static str = REQUEST__Rename;
+}
+
 pub const REQUEST__Rename: &'static str = "textDocument/rename";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ use serde::de;
 use serde::de::Error as Error_;
 use serde_json::Value;
 
+pub mod notification;
+pub mod request;
 
 /* ----------------- Auxiliary types ----------------- */
 
@@ -49,36 +51,7 @@ pub enum NumberOrString {
     String(String),
 }
 
-/* ----------------- Message typing ----------------- */
-
-pub trait Request {
-    type Params;
-    type Result;
-    const METHOD: &'static str;
-}
-
-pub trait Notification {
-    type Params;
-    const METHOD: &'static str;
-}
-
 /* ----------------- Cancel support ----------------- */
-
-/// The base protocol now offers support for request cancellation. To cancel a request,
-/// a notification message with the following properties is sent:
-///
-/// A request that got canceled still needs to return from the server and send a response back.
-/// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
-/// that every request sends a response back. In addition it allows for returning partial results on cancel.
-#[derive(Debug)]
-pub enum Cancel { }
-
-impl Notification for Cancel {
-    type Params = CancelParams;
-    const METHOD: &'static str = NOTIFICATION__Cancel;
-}
-
-pub const NOTIFICATION__Cancel: &'static str = "$/cancelRequest";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CancelParams {
@@ -494,40 +467,6 @@ pub struct DocumentFilter {
 pub type DocumentSelector = Vec<DocumentFilter>;
 
 // ========================= Actual Protocol =========================
-
-/**
-
- The initialize request is sent as the first request from the client to the server.
- If the server receives request or notification before the `initialize` request it should act as follows:
-
- * for a request the respond should be errored with `code: -32001`. The message can be picked by the server.
- * notifications should be dropped.
-
-*/
-#[derive(Debug)]
-pub enum Initialize { }
-
-impl Request for Initialize {
-    type Params = InitializeParams;
-    type Result = InitializeResult;
-    const METHOD: &'static str = REQUEST__Initialize;
-}
-
-pub const REQUEST__Initialize: &'static str = "initialize";
-
-/// The initialized notification is sent from the client to the server after the client received
-/// the result of the initialize request but before the client is sending any other request or
-/// notification to the server. The server can use the initialized notification for example to
-/// dynamically register capabilities.
-#[derive(Debug)]
-pub enum Initialized { }
-
-impl Notification for Initialized {
-    type Params = ();
-    const METHOD: &'static str = NOTIFICATION__Initialized;
-}
-
-pub const NOTIFICATION__Initialized: &'static str = "initialized";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct InitializeParams {
@@ -1016,51 +955,6 @@ pub struct ServerCapabilities {
     pub execute_command_provider: Option<ExecuteCommandOptions>,
 }
 
-/**
- * The shutdown request is sent from the client to the server. It asks the server to shut down,
- * but to not exit (otherwise the response might not be delivered correctly to the client).
- * There is a separate exit notification that asks the server to exit.
- */
-#[derive(Debug)]
-pub enum Shutdown { }
-
-impl Request for Shutdown {
-    type Params = ();
-    type Result = ();
-    const METHOD: &'static str = REQUEST__Shutdown;
-}
-
-pub const REQUEST__Shutdown: &'static str = "shutdown";
-
-/**
- * A notification to ask the server to exit its process.
- * The server should exit with success code 0 if the shutdown request has been received before;
- * otherwise with error code 1.
- */
-#[derive(Debug)]
-pub enum Exit { }
-
-impl Notification for Exit {
-    type Params = ();
-    const METHOD: &'static str = NOTIFICATION__Exit;
-}
-
-pub const NOTIFICATION__Exit: &'static str = "exit";
-
-/**
- * The show message notification is sent from a server to a client to ask the client to display a particular message
- * in the user interface.
- */
-#[derive(Debug)]
-pub enum ShowMessage { }
-
-impl Notification for ShowMessage {
-    type Params = ShowMessageParams;
-    const METHOD: &'static str = NOTIFICATION__ShowMessage;
-}
-
-pub const NOTIFICATION__ShowMessage: &'static str = "window/showMessage";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ShowMessageParams {
     /// The message type. See {@link MessageType}.
@@ -1112,23 +1006,6 @@ impl serde::Serialize for MessageType {
     }
 }
 
-/**
- * The show message request is sent from a server to a client to ask the client to display a particular message
- * in the user interface. In addition to the show message notification the request allows to pass actions and to
- * wait for an answer from the client.
- */
-#[derive(Debug)]
-pub enum ShowMessageRequest { }
-
-impl Request for ShowMessageRequest {
-    type Params = ShowMessageRequestParams;
-    type Result = Option<MessageActionItem>;
-    const METHOD: &'static str = REQUEST__ShowMessageRequest;
-}
-
-pub const REQUEST__ShowMessageRequest: &'static str = "window/showMessageRequest";
-
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ShowMessageRequestParams {
     /// The message type. See {@link MessageType}
@@ -1149,19 +1026,6 @@ pub struct MessageActionItem {
     pub title: String,
 }
 
-/**
- * The log message notification is sent from the server to the client to ask the client to log a particular message.
- */
-#[derive(Debug)]
-pub enum LogMessage { }
-
-impl Notification for LogMessage {
-    type Params = LogMessageParams;
-    const METHOD: &'static str = NOTIFICATION__LogMessage;
-}
-
-pub const NOTIFICATION__LogMessage: &'static str = "window/logMessage";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct LogMessageParams {
     /// The message type. See {@link MessageType}
@@ -1171,33 +1035,6 @@ pub struct LogMessageParams {
     /// The actual message
     pub message: String,
 }
-
-/**
- * The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
- */
-#[derive(Debug)]
-pub enum TelemetryEvent { }
-
-impl Notification for TelemetryEvent {
-    type Params = ();
-    const METHOD: &'static str = NOTIFICATION__TelemetryEvent;
-}
-
-pub const NOTIFICATION__TelemetryEvent: &'static str = "telemetry/event";
-
-
-/**
- * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
- */
-#[derive(Debug)]
-pub enum RegisterCapability { }
-
-impl Notification for RegisterCapability {
-    type Params = RegistrationParams;
-    const METHOD: &'static str = NOTIFICATION__RegisterCapability;
-}
-
-pub const NOTIFICATION__RegisterCapability: &'static str = "client/registerCapability";
 
 /**
  * General parameters to to register for a capability.
@@ -1239,18 +1076,6 @@ pub struct TextDocumentRegistrationOptions {
     pub document_selector: Option<DocumentSelector>,
 }
 
-/// The client/unregisterCapability request is sent from the server to the client to unregister a
-/// previously register capability.
-#[derive(Debug)]
-pub enum UnregisterCapability { }
-
-impl Notification for UnregisterCapability {
-    type Params = UnregistrationParams;
-    const METHOD: &'static str = NOTIFICATION__UnregisterCapability;
-}
-
-pub const NOTIFICATION__UnregisterCapability: &'static str = "client/unregisterCapability";
-
 /**
  * General parameters to unregister a capability.
  */
@@ -1273,39 +1098,11 @@ pub struct UnregistrationParams {
     pub unregisterations: Vec<Unregistration>,
 }
 
-/**
- * A notification sent from the client to the server to signal the change of configuration settings.
- */
-#[derive(Debug)]
-pub enum DidChangeConfiguration { }
-
-impl Notification for DidChangeConfiguration {
-    type Params = DidChangeConfigurationParams;
-    const METHOD: &'static str = NOTIFICATION__WorkspaceChangeConfiguration;
-}
-
-pub const NOTIFICATION__WorkspaceChangeConfiguration: &'static str = "workspace/didChangeConfiguration";
-
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct DidChangeConfigurationParams {
     /// The actual changed settings
     pub settings: Value,
 }
-
-/**
- * The document open notification is sent from the client to the server to signal newly opened text documents.
- * The document's truth is now managed by the client and the server must not try to read the document's truth
- * using the document's uri.
- */
-#[derive(Debug)]
-pub enum DidOpenTextDocument { }
-
-impl Notification for DidOpenTextDocument {
-    type Params = DidOpenTextDocumentParams;
-    const METHOD: &'static str = NOTIFICATION__DidOpenTextDocument;
-}
-
-pub const NOTIFICATION__DidOpenTextDocument: &'static str = "textDocument/didOpen";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DidOpenTextDocumentParams {
@@ -1313,20 +1110,6 @@ pub struct DidOpenTextDocumentParams {
     #[serde(rename = "textDocument")]
     pub text_document: TextDocumentItem,
 }
-
-/**
- * The document change notification is sent from the client to the server to signal changes to a text document.
- * In 2.0 the shape of the params has changed to include proper version numbers and language ids.
- */
-#[derive(Debug)]
-pub enum DidChangeTextDocument { }
-
-impl Notification for DidChangeTextDocument {
-    type Params = DidChangeTextDocumentParams;
-    const METHOD: &'static str = NOTIFICATION__DidChangeTextDocument;
-}
-
-pub const NOTIFICATION__DidChangeTextDocument: &'static str = "textDocument/didChange";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DidChangeTextDocumentParams {
@@ -1377,33 +1160,6 @@ pub struct TextDocumentChangeRegistrationOptions {
     #[serde(rename = "syncKind")]
     pub sync_kind: i32,
 }
-
-/// The document will save notification is sent from the client to the server before the document
-/// is actually saved.
-#[derive(Debug)]
-pub enum WillSave { }
-
-impl Notification for WillSave {
-    type Params = ();
-    const METHOD: &'static str = NOTIFICATION__WillSave;
-}
-
-pub const NOTIFICATION__WillSave: &'static str = "textDocument/willSave";
-
-/// The document will save request is sent from the client to the server before the document is
-/// actually saved. The request can return an array of TextEdits which will be applied to the text
-/// document before it is saved. Please note that clients might drop results if computing the text
-/// edits took too long or if a server constantly fails on this request. This is done to keep the
-/// save fast and reliable.
-#[derive(Debug)]
-pub enum WillSaveWaitUntil { }
-
-impl Notification for WillSaveWaitUntil {
-    type Params = ();
-    const METHOD: &'static str = NOTIFICATION__WillSaveWaitUntil;
-}
-
-pub const NOTIFICATION__WillSaveWaitUntil: &'static str = "textDocument/willSaveWaitUntil";
 
 /**
  * The parameters send in a will save text document notification.
@@ -1473,21 +1229,6 @@ impl serde::Serialize for TextDocumentSaveReason {
     }
 }
 
-/**
- * The document close notification is sent from the client to the server when the document got closed in the client.
- * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri
- * the truth now exists on disk).
- */
-#[derive(Debug)]
-pub enum DidCloseTextDocument { }
-
-impl Notification for DidCloseTextDocument {
-    type Params = DidCloseTextDocumentParams;
-    const METHOD: &'static str = NOTIFICATION__DidCloseTextDocument;
-}
-
-pub const NOTIFICATION__DidCloseTextDocument: &'static str = "textDocument/didClose";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DidCloseTextDocumentParams {
     /// The document that was closed.
@@ -1495,39 +1236,12 @@ pub struct DidCloseTextDocumentParams {
     pub text_document: TextDocumentIdentifier,
 }
 
-/**
- * The document save notification is sent from the client to the server when the document was saved in the client.
- */
-#[derive(Debug)]
-pub enum DidSaveTextDocument { }
-
-impl Notification for DidSaveTextDocument {
-    type Params = DidSaveTextDocumentParams;
-    const METHOD: &'static str = NOTIFICATION__DidSaveTextDocument;
-}
-
-pub const NOTIFICATION__DidSaveTextDocument: &'static str = "textDocument/didSave";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DidSaveTextDocumentParams {
     /// The document that was saved.
     #[serde(rename = "textDocument")]
     pub text_document: TextDocumentIdentifier,
 }
-
-/**
- * The watched files notification is sent from the client to the server when the client detects changes to files
- * watched by the language client.
- */
-#[derive(Debug)]
-pub enum DidChangeWatchedFiles { }
-
-impl Notification for DidChangeWatchedFiles {
-    type Params = DidChangeWatchedFilesParams;
-    const METHOD: &'static str = NOTIFICATION__DidChangeWatchedFiles;
-}
-
-pub const NOTIFICATION__DidChangeWatchedFiles: &'static str = "workspace/didChangeWatchedFiles";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DidChangeWatchedFilesParams {
@@ -1594,19 +1308,6 @@ impl FileEvent {
     }
 }
 
-/**
- * Diagnostics notification are sent from the server to the client to signal results of validation runs.
- */
-#[derive(Debug)]
-pub enum PublishDiagnostics { }
-
-impl Notification for PublishDiagnostics {
-    type Params = PublishDiagnosticsParams;
-    const METHOD: &'static str = NOTIFICATION__PublishDiagnostics;
-}
-
-pub const NOTIFICATION__PublishDiagnostics: &'static str = "textDocument/publishDiagnostics";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct PublishDiagnosticsParams {
     /// The URI for which diagnostic information is reported.
@@ -1625,27 +1326,6 @@ impl PublishDiagnosticsParams {
         }
     }
 }
-
-/**
- The Completion request is sent from the client to the server to compute completion items at a given cursor position.
- Completion items are presented in the IntelliSense user interface. If computing full completion items is expensive,
- servers can additionally provide a handler for the completion item resolve request ('completionItem/resolve').
- This request is sent when a completion item is selected in the user interface. A typically use case is for example:
- the 'textDocument/completion' request doesn't fill in the documentation property for returned completion items
- since it is expensive to compute. When the item is selected in the user interface then a 'completionItem/resolve'
- request is sent with the selected completion item as a param. The returned completion item should have the
- documentation property filled in.
-*/
-#[derive(Debug)]
-pub enum Completion { }
-
-impl Request for Completion {
-    type Params = TextDocumentPositionParams; // TODO: extend with CompletionContext as CompletionParams
-    type Result = CompletionResponse;
-    const METHOD: &'static str = REQUEST__Completion;
-}
-
-pub const REQUEST__Completion: &'static str = "textDocument/completion";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1835,31 +1515,6 @@ impl serde::Serialize for InsertTextFormat {
     }
 }
 
-/// The request is sent from the client to the server to resolve additional information for a given completion item.
-#[derive(Debug)]
-pub enum ResolveCompletionItem { }
-
-impl Request for ResolveCompletionItem {
-    type Params = CompletionItem;
-    type Result = CompletionItem;
-    const METHOD: &'static str = REQUEST__ResolveCompletionItem;
-}
-
-pub const REQUEST__ResolveCompletionItem: &'static str = "completionItem/resolve";
-
-/// The hover request is sent from the client to the server to request hover information at a given text
-/// document position.
-#[derive(Debug)]
-pub enum HoverRequest { }
-
-impl Request for HoverRequest {
-    type Params = TextDocumentPositionParams;
-    type Result = Option<Hover>;
-    const METHOD: &'static str = REQUEST__Hover;
-}
-
-pub const REQUEST__Hover: &'static str = "textDocument/hover";
-
 /// The result of a hover request.
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Hover {
@@ -1918,20 +1573,6 @@ impl MarkedString {
     }
 }
 
-/// The signature help request is sent from the client to the server to request signature information at
-/// a given cursor position.
-#[derive(Debug)]
-pub enum SignatureHelpRequest { }
-
-impl Request for SignatureHelpRequest {
-    type Params = TextDocumentPositionParams;
-    type Result = Option<SignatureHelp>;
-    const METHOD: &'static str = REQUEST__SignatureHelp;
-}
-
-pub const REQUEST__SignatureHelp: &'static str = "textDocument/signatureHelp";
-
-
 /// Signature help represents the signature of something
 /// callable. There can be multiple signature but only one
 /// active and only one active parameter.
@@ -1981,33 +1622,6 @@ pub struct ParameterInformation {
     pub documentation: Option<String>,
 }
 
-/// The goto definition request is sent from the client to the server to resolve the definition location of
-/// a symbol at a given text document position.
-#[derive(Debug)]
-pub enum GotoDefinition { }
-
-impl Request for GotoDefinition {
-    type Params = TextDocumentPositionParams;
-    type Result = Option<GotoDefinitionResponse>;
-    const METHOD: &'static str = REQUEST__GotoDefinition;
-}
-
-/**
- * GotoDefinition response can be single location or multiple ones.
- */
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum GotoDefinitionResponse {
-    Scalar(Location),
-    Array(Vec<Location>),
-}
-
-pub const REQUEST__GotoDefinition: &'static str = "textDocument/definition";
-
-/// The references request is sent from the client to the server to resolve project-wide references for the
-/// symbol denoted by the given text document position.
-pub const REQUEST__References: &'static str = "textDocument/references";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ReferenceParams {
     // This field was "mixed-in" from TextDocumentPositionParams
@@ -2029,26 +1643,6 @@ pub struct ReferenceContext {
     #[serde(rename = "includeDeclaration")]
     pub include_declaration: bool,
 }
-
-/**
- The document highlight request is sent from the client to the server to resolve a document highlights
- for a given text document position.
- For programming languages this usually highlights all references to the symbol scoped to this file.
- However we kept 'textDocument/documentHighlight' and 'textDocument/references' separate requests since
- the first one is allowed to be more fuzzy.
- Symbol matches usually have a DocumentHighlightKind of Read or Write whereas fuzzy or textual matches
- use Textas the kind.
-*/
-#[derive(Debug)]
-pub enum DocumentHighlightRequest { }
-
-impl Request for DocumentHighlightRequest {
-    type Params = TextDocumentPositionParams;
-    type Result = Option<Vec<DocumentHighlight>>;
-    const METHOD: &'static str = REQUEST__DocumentHighlight;
-}
-
-pub const REQUEST__DocumentHighlight: &'static str = "textDocument/documentHighlight";
 
 /// A document highlight is a range inside a text document which deserves
 /// special attention. Usually a document highlight is visualized by changing
@@ -2102,21 +1696,6 @@ impl serde::Serialize for DocumentHighlightKind {
         serializer.serialize_u8(*self as u8)
     }
 }
-
-/**
- * The document symbol request is sent from the client to the server to list all symbols found in a given
- * text document.
- */
-#[derive(Debug)]
-pub enum DocumentSymbol { }
-
-impl Request for DocumentSymbol {
-    type Params = DocumentSymbolParams;
-    type Result = Option<Vec<SymbolInformation>>;
-    const METHOD: &'static str = REQUEST__DocumentSymbols;
-}
-
-pub const REQUEST__DocumentSymbols: &'static str = "textDocument/documentSymbol";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DocumentSymbolParams {
@@ -2194,39 +1773,12 @@ impl serde::Serialize for SymbolKind {
     }
 }
 
-/**
- * The workspace symbol request is sent from the client to the server to list project-wide symbols
- * matching the query string.
- */
-#[derive(Debug)]
-pub enum WorkspaceSymbol { }
-
-impl Request for WorkspaceSymbol {
-    type Params = WorkspaceSymbolParams;
-    type Result = Option<Vec<SymbolInformation>>;
-    const METHOD: &'static str = REQUEST__WorkspaceSymbols;
-}
-
-pub const REQUEST__WorkspaceSymbols: &'static str = "workspace/symbol";
-
 /// The parameters of a Workspace Symbol Request.
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct WorkspaceSymbolParams {
     /// A non-empty query string
     pub query: String,
 }
-
-/// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server. In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request workspace/applyEdit which is sent from the server to the client.
-#[derive(Debug)]
-pub enum ExecuteCommand { }
-
-impl Request for ExecuteCommand {
-    type Params = ExecuteCommandParams;
-    type Result = Option<Value>;
-    const METHOD: &'static str = REQUEST__ExecuteCommand;
-}
-
-pub const REQUEST__ExecuteCommand: &'static str = "workspace/executeCommand";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct ExecuteCommandParams {
@@ -2252,20 +1804,6 @@ pub struct ExecuteCommandRegistrationOptions {
     pub commands: Vec<String>,
 }
 
-
-/// The workspace/applyEdit request is sent from the server to the client to modify resource on the
-/// client side.
-#[derive(Debug)]
-pub enum ApplyWorkspaceEdit { }
-
-impl Request for ApplyWorkspaceEdit {
-    type Params = ApplyWorkspaceEditParams;
-    type Result = ApplyWorkspaceEditResponse;
-    const METHOD: &'static str = REQUEST__ApplyEdit;
-}
-
-pub const REQUEST__ApplyEdit: &'static str = "workspace/applyEdit";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ApplyWorkspaceEditParams {
     /**
@@ -2281,22 +1819,6 @@ pub struct ApplyWorkspaceEditResponse {
      */
     pub applied: bool,
 }
-
-/**
- * The code action request is sent from the client to the server to compute commands for a given text document
- * and range. The request is triggered when the user moves the cursor into a problem marker in the editor or
- * presses the lightbulb associated with a marker.
- */
-#[derive(Debug)]
-pub enum CodeActionRequest { }
-
-impl Request for CodeActionRequest {
-    type Params = CodeActionParams;
-    type Result = Option<Vec<Command>>;
-    const METHOD: &'static str = REQUEST__CodeAction;
-}
-
-pub const REQUEST__CodeAction: &'static str = "textDocument/codeAction";
 
 /// Params for the CodeActionRequest
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2319,20 +1841,6 @@ pub struct CodeActionContext {
     /// An array of diagnostics.
     pub diagnostics: Vec<Diagnostic>,
 }
-
-/**
- * The code lens request is sent from the client to the server to compute code lenses for a given text document.
- */
-#[derive(Debug)]
-pub enum CodeLensRequest { }
-
-impl Request for CodeLensRequest {
-    type Params = CodeLensParams;
-    type Result = Option<Vec<CodeLens>>;
-    const METHOD: &'static str = REQUEST__CodeLens;
-}
-
-pub const REQUEST__CodeLens: &'static str = "textDocument/codeLens";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CodeLensParams {
@@ -2359,37 +1867,6 @@ pub struct CodeLens {
     pub data: Option<Value>,
 }
 
-/**
- * The code lens resolve request is sent from the client to the server to resolve the command for a
- * given code lens item.
- */
-#[derive(Debug)]
-pub enum CodeLensResolve { }
-
-impl Request for CodeLensResolve {
-    type Params = CodeLens;
-    type Result = CodeLens;
-    const METHOD: &'static str = REQUEST__CodeLensResolve;
-}
-
-pub const REQUEST__CodeLensResolve: &'static str = "codeLens/resolve";
-
-/**
-
- The document links request is sent from the client to the server to request the location of links in a document.
-
-*/
-#[derive(Debug)]
-pub enum DocumentLinkRequest { }
-
-impl Request for DocumentLinkRequest {
-    type Params = DocumentLinkParams;
-    type Result = Option<Vec<DocumentLink>>;
-    const METHOD: &'static str = REQUEST__DocumentLink;
-}
-
-pub const REQUEST__DocumentLink: &'static str = "textDocument/documentLink";
-
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DocumentLinkParams {
     /**
@@ -2415,38 +1892,6 @@ pub struct DocumentLink {
     #[serde(with = "url_serde")]
     pub target: Url,
 }
-
-/**
-
- The document link resolve request is sent from the client to the server to resolve the target of
- a given document link.
-
-*/
-#[derive(Debug)]
-pub enum DocumentLinkResolve { }
-
-impl Request for DocumentLinkResolve {
-    type Params = DocumentLink;
-    type Result = DocumentLink;
-    const METHOD: &'static str = REQUEST__DocumentLinkResolve;
-}
-
-pub const REQUEST__DocumentLinkResolve: &'static str = "documentLink/resolve";
-
-
-/**
- * The document formatting request is sent from the server to the client to format a whole document.
- */
-#[derive(Debug)]
-pub enum Formatting { }
-
-impl Request for Formatting {
-    type Params = DocumentFormattingParams;
-    type Result = Option<Vec<TextEdit>>;
-    const METHOD: &'static str = REQUEST__Formatting;
-}
-
-pub const REQUEST__Formatting: &'static str = "textDocument/formatting";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct DocumentFormattingParams {
@@ -2558,19 +2003,6 @@ impl serde::Serialize for FormattingOptions {
     }
 }
 
-
-/// The document range formatting request is sent from the client to the server to format a given range in a document.
-#[derive(Debug)]
-pub enum RangeFormatting { }
-
-impl Request for RangeFormatting {
-    type Params = DocumentRangeFormattingParams;
-    type Result = Option<Vec<TextEdit>>;
-    const METHOD: &'static str = REQUEST__RangeFormatting;
-}
-
-pub const REQUEST__RangeFormatting: &'static str = "textDocument/rangeFormatting";
-
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct DocumentRangeFormattingParams {
     /// The document to format.
@@ -2583,21 +2015,6 @@ pub struct DocumentRangeFormattingParams {
     /// The format options
     pub options: FormattingOptions,
 }
-
-/**
- * The document on type formatting request is sent from the client to the server to format parts of
- * the document during typing.
- */
-#[derive(Debug)]
-pub enum OnTypeFormatting { }
-
-impl Request for OnTypeFormatting {
-    type Params = DocumentOnTypeFormattingParams;
-    type Result = Option<Vec<TextEdit>>;
-    const METHOD: &'static str = REQUEST__OnTypeFormatting;
-}
-
-pub const REQUEST__OnTypeFormatting: &'static str = "textDocument/onTypeFormatting";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct DocumentOnTypeFormattingParams {
@@ -2637,20 +2054,6 @@ pub struct DocumentOnTypeFormattingRegistrationOptions {
     #[serde(rename = "moreTriggerCharacter")]
     pub more_trigger_character: Option<Vec<String>>,
 }
-
-/**
- * The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
- */
-#[derive(Debug)]
-pub enum Rename { }
-
-impl Request for Rename {
-    type Params = RenameParams;
-    type Result = Option<WorkspaceEdit>;
-    const METHOD: &'static str = REQUEST__Rename;
-}
-
-pub const REQUEST__Rename: &'static str = "textDocument/rename";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RenameParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub trait Notification {
 /// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
 /// that every request sends a response back. In addition it allows for returning partial results on cancel.
 #[derive(Debug)]
-pub struct Cancel;
+pub enum Cancel { }
 
 impl Notification for Cancel {
     type Params = CancelParams;
@@ -505,7 +505,7 @@ pub type DocumentSelector = Vec<DocumentFilter>;
 
 */
 #[derive(Debug)]
-pub struct Initialize;
+pub enum Initialize { }
 
 impl Request for Initialize {
     type Params = InitializeParams;
@@ -520,7 +520,7 @@ pub const REQUEST__Initialize: &'static str = "initialize";
 /// notification to the server. The server can use the initialized notification for example to
 /// dynamically register capabilities.
 #[derive(Debug)]
-pub struct Initialized;
+pub enum Initialized { }
 
 impl Notification for Initialized {
     type Params = ();
@@ -1022,7 +1022,7 @@ pub struct ServerCapabilities {
  * There is a separate exit notification that asks the server to exit.
  */
 #[derive(Debug)]
-pub struct Shutdown;
+pub enum Shutdown { }
 
 impl Request for Shutdown {
     type Params = ();
@@ -1038,7 +1038,7 @@ pub const REQUEST__Shutdown: &'static str = "shutdown";
  * otherwise with error code 1.
  */
 #[derive(Debug)]
-pub struct Exit;
+pub enum Exit { }
 
 impl Notification for Exit {
     type Params = ();
@@ -1052,7 +1052,7 @@ pub const NOTIFICATION__Exit: &'static str = "exit";
  * in the user interface.
  */
 #[derive(Debug)]
-pub struct ShowMessage;
+pub enum ShowMessage { }
 
 impl Notification for ShowMessage {
     type Params = ShowMessageParams;
@@ -1118,7 +1118,7 @@ impl serde::Serialize for MessageType {
  * wait for an answer from the client.
  */
 #[derive(Debug)]
-pub struct ShowMessageRequest;
+pub enum ShowMessageRequest { }
 
 impl Request for ShowMessageRequest {
     type Params = ShowMessageRequestParams;
@@ -1153,7 +1153,7 @@ pub struct MessageActionItem {
  * The log message notification is sent from the server to the client to ask the client to log a particular message.
  */
 #[derive(Debug)]
-pub struct LogMessage;
+pub enum LogMessage { }
 
 impl Notification for LogMessage {
     type Params = LogMessageParams;
@@ -1176,7 +1176,7 @@ pub struct LogMessageParams {
  * The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
  */
 #[derive(Debug)]
-pub struct TelemetryEvent;
+pub enum TelemetryEvent { }
 
 impl Notification for TelemetryEvent {
     type Params = ();
@@ -1190,7 +1190,7 @@ pub const NOTIFICATION__TelemetryEvent: &'static str = "telemetry/event";
  * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
  */
 #[derive(Debug)]
-pub struct RegisterCapability;
+pub enum RegisterCapability { }
 
 impl Notification for RegisterCapability {
     type Params = RegistrationParams;
@@ -1242,7 +1242,7 @@ pub struct TextDocumentRegistrationOptions {
 /// The client/unregisterCapability request is sent from the server to the client to unregister a
 /// previously register capability.
 #[derive(Debug)]
-pub struct UnregisterCapability;
+pub enum UnregisterCapability { }
 
 impl Notification for UnregisterCapability {
     type Params = UnregistrationParams;
@@ -1277,7 +1277,7 @@ pub struct UnregistrationParams {
  * A notification sent from the client to the server to signal the change of configuration settings.
  */
 #[derive(Debug)]
-pub struct DidChangeConfiguration;
+pub enum DidChangeConfiguration { }
 
 impl Notification for DidChangeConfiguration {
     type Params = DidChangeConfigurationParams;
@@ -1298,7 +1298,7 @@ pub struct DidChangeConfigurationParams {
  * using the document's uri.
  */
 #[derive(Debug)]
-pub struct DidOpenTextDocument;
+pub enum DidOpenTextDocument { }
 
 impl Notification for DidOpenTextDocument {
     type Params = DidOpenTextDocumentParams;
@@ -1319,7 +1319,7 @@ pub struct DidOpenTextDocumentParams {
  * In 2.0 the shape of the params has changed to include proper version numbers and language ids.
  */
 #[derive(Debug)]
-pub struct DidChangeTextDocument;
+pub enum DidChangeTextDocument { }
 
 impl Notification for DidChangeTextDocument {
     type Params = DidChangeTextDocumentParams;
@@ -1381,7 +1381,7 @@ pub struct TextDocumentChangeRegistrationOptions {
 /// The document will save notification is sent from the client to the server before the document
 /// is actually saved.
 #[derive(Debug)]
-pub struct WillSave;
+pub enum WillSave { }
 
 impl Notification for WillSave {
     type Params = ();
@@ -1396,7 +1396,7 @@ pub const NOTIFICATION__WillSave: &'static str = "textDocument/willSave";
 /// edits took too long or if a server constantly fails on this request. This is done to keep the
 /// save fast and reliable.
 #[derive(Debug)]
-pub struct WillSaveWaitUntil;
+pub enum WillSaveWaitUntil { }
 
 impl Notification for WillSaveWaitUntil {
     type Params = ();
@@ -1479,7 +1479,7 @@ impl serde::Serialize for TextDocumentSaveReason {
  * the truth now exists on disk).
  */
 #[derive(Debug)]
-pub struct DidCloseTextDocument;
+pub enum DidCloseTextDocument { }
 
 impl Notification for DidCloseTextDocument {
     type Params = DidCloseTextDocumentParams;
@@ -1499,7 +1499,7 @@ pub struct DidCloseTextDocumentParams {
  * The document save notification is sent from the client to the server when the document was saved in the client.
  */
 #[derive(Debug)]
-pub struct DidSaveTextDocument;
+pub enum DidSaveTextDocument { }
 
 impl Notification for DidSaveTextDocument {
     type Params = DidSaveTextDocumentParams;
@@ -1520,7 +1520,7 @@ pub struct DidSaveTextDocumentParams {
  * watched by the language client.
  */
 #[derive(Debug)]
-pub struct DidChangeWatchedFiles;
+pub enum DidChangeWatchedFiles { }
 
 impl Notification for DidChangeWatchedFiles {
     type Params = DidChangeWatchedFilesParams;
@@ -1598,7 +1598,7 @@ impl FileEvent {
  * Diagnostics notification are sent from the server to the client to signal results of validation runs.
  */
 #[derive(Debug)]
-pub struct PublishDiagnostics;
+pub enum PublishDiagnostics { }
 
 impl Notification for PublishDiagnostics {
     type Params = PublishDiagnosticsParams;
@@ -1637,7 +1637,7 @@ impl PublishDiagnosticsParams {
  documentation property filled in.
 */
 #[derive(Debug)]
-pub struct Completion;
+pub enum Completion { }
 
 impl Request for Completion {
     type Params = TextDocumentPositionParams; // TODO: extend with CompletionContext as CompletionParams
@@ -1837,7 +1837,7 @@ impl serde::Serialize for InsertTextFormat {
 
 /// The request is sent from the client to the server to resolve additional information for a given completion item.
 #[derive(Debug)]
-pub struct ResolveCompletionItem;
+pub enum ResolveCompletionItem { }
 
 impl Request for ResolveCompletionItem {
     type Params = CompletionItem;
@@ -1850,7 +1850,7 @@ pub const REQUEST__ResolveCompletionItem: &'static str = "completionItem/resolve
 /// The hover request is sent from the client to the server to request hover information at a given text
 /// document position.
 #[derive(Debug)]
-pub struct HoverRequest;
+pub enum HoverRequest { }
 
 impl Request for HoverRequest {
     type Params = TextDocumentPositionParams;
@@ -1921,7 +1921,7 @@ impl MarkedString {
 /// The signature help request is sent from the client to the server to request signature information at
 /// a given cursor position.
 #[derive(Debug)]
-pub struct SignatureHelpRequest;
+pub enum SignatureHelpRequest { }
 
 impl Request for SignatureHelpRequest {
     type Params = TextDocumentPositionParams;
@@ -1984,7 +1984,7 @@ pub struct ParameterInformation {
 /// The goto definition request is sent from the client to the server to resolve the definition location of
 /// a symbol at a given text document position.
 #[derive(Debug)]
-pub struct GotoDefinition;
+pub enum GotoDefinition { }
 
 impl Request for GotoDefinition {
     type Params = TextDocumentPositionParams;
@@ -2040,7 +2040,7 @@ pub struct ReferenceContext {
  use Textas the kind.
 */
 #[derive(Debug)]
-pub struct DocumentHighlightRequest;
+pub enum DocumentHighlightRequest { }
 
 impl Request for DocumentHighlightRequest {
     type Params = TextDocumentPositionParams;
@@ -2108,7 +2108,7 @@ impl serde::Serialize for DocumentHighlightKind {
  * text document.
  */
 #[derive(Debug)]
-pub struct DocumentSymbol;
+pub enum DocumentSymbol { }
 
 impl Request for DocumentSymbol {
     type Params = DocumentSymbolParams;
@@ -2199,7 +2199,7 @@ impl serde::Serialize for SymbolKind {
  * matching the query string.
  */
 #[derive(Debug)]
-pub struct WorkspaceSymbol;
+pub enum WorkspaceSymbol { }
 
 impl Request for WorkspaceSymbol {
     type Params = WorkspaceSymbolParams;
@@ -2218,7 +2218,7 @@ pub struct WorkspaceSymbolParams {
 
 /// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server. In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request workspace/applyEdit which is sent from the server to the client.
 #[derive(Debug)]
-pub struct ExecuteCommand;
+pub enum ExecuteCommand { }
 
 impl Request for ExecuteCommand {
     type Params = ExecuteCommandParams;
@@ -2256,7 +2256,7 @@ pub struct ExecuteCommandRegistrationOptions {
 /// The workspace/applyEdit request is sent from the server to the client to modify resource on the
 /// client side.
 #[derive(Debug)]
-pub struct ApplyWorkspaceEdit;
+pub enum ApplyWorkspaceEdit { }
 
 impl Request for ApplyWorkspaceEdit {
     type Params = ApplyWorkspaceEditParams;
@@ -2288,7 +2288,7 @@ pub struct ApplyWorkspaceEditResponse {
  * presses the lightbulb associated with a marker.
  */
 #[derive(Debug)]
-pub struct CodeActionRequest;
+pub enum CodeActionRequest { }
 
 impl Request for CodeActionRequest {
     type Params = CodeActionParams;
@@ -2324,7 +2324,7 @@ pub struct CodeActionContext {
  * The code lens request is sent from the client to the server to compute code lenses for a given text document.
  */
 #[derive(Debug)]
-pub struct CodeLensRequest;
+pub enum CodeLensRequest { }
 
 impl Request for CodeLensRequest {
     type Params = CodeLensParams;
@@ -2364,7 +2364,7 @@ pub struct CodeLens {
  * given code lens item.
  */
 #[derive(Debug)]
-pub struct CodeLensResolve;
+pub enum CodeLensResolve { }
 
 impl Request for CodeLensResolve {
     type Params = CodeLens;
@@ -2380,7 +2380,7 @@ pub const REQUEST__CodeLensResolve: &'static str = "codeLens/resolve";
 
 */
 #[derive(Debug)]
-pub struct DocumentLinkRequest;
+pub enum DocumentLinkRequest { }
 
 impl Request for DocumentLinkRequest {
     type Params = DocumentLinkParams;
@@ -2423,7 +2423,7 @@ pub struct DocumentLink {
 
 */
 #[derive(Debug)]
-pub struct DocumentLinkResolve;
+pub enum DocumentLinkResolve { }
 
 impl Request for DocumentLinkResolve {
     type Params = DocumentLink;
@@ -2438,7 +2438,7 @@ pub const REQUEST__DocumentLinkResolve: &'static str = "documentLink/resolve";
  * The document formatting request is sent from the server to the client to format a whole document.
  */
 #[derive(Debug)]
-pub struct Formatting;
+pub enum Formatting { }
 
 impl Request for Formatting {
     type Params = DocumentFormattingParams;
@@ -2561,7 +2561,7 @@ impl serde::Serialize for FormattingOptions {
 
 /// The document range formatting request is sent from the client to the server to format a given range in a document.
 #[derive(Debug)]
-pub struct RangeFormatting;
+pub enum RangeFormatting { }
 
 impl Request for RangeFormatting {
     type Params = DocumentRangeFormattingParams;
@@ -2589,7 +2589,7 @@ pub struct DocumentRangeFormattingParams {
  * the document during typing.
  */
 #[derive(Debug)]
-pub struct OnTypeFormatting;
+pub enum OnTypeFormatting { }
 
 impl Request for OnTypeFormatting {
     type Params = DocumentOnTypeFormattingParams;
@@ -2642,7 +2642,7 @@ pub struct DocumentOnTypeFormattingRegistrationOptions {
  * The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
  */
 #[derive(Debug)]
-pub struct Rename;
+pub enum Rename { }
 
 impl Request for Rename {
     type Params = RenameParams;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,19 @@ pub enum NumberOrString {
     String(String),
 }
 
+/* ----------------- Message typing ----------------- */
+
+pub trait Request {
+    type Params;
+    type Result;
+    const METHOD: &'static str;
+}
+
+pub trait Notification {
+    type Params;
+    const METHOD: &'static str;
+}
+
 /* ----------------- Cancel support ----------------- */
 
 /// The base protocol now offers support for request cancellation. To cancel a request,
@@ -57,6 +70,14 @@ pub enum NumberOrString {
 /// A request that got canceled still needs to return from the server and send a response back.
 /// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
 /// that every request sends a response back. In addition it allows for returning partial results on cancel.
+#[derive(Debug)]
+pub struct Cancel;
+
+impl Notification for Cancel {
+    type Params = CancelParams;
+    const METHOD: &'static str = NOTIFICATION__Cancel;
+}
+
 pub const NOTIFICATION__Cancel: &'static str = "$/cancelRequest";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -489,7 +510,16 @@ pub const REQUEST__Initialize: &'static str = "initialize";
 /// the result of the initialize request but before the client is sending any other request or
 /// notification to the server. The server can use the initialized notification for example to
 /// dynamically register capabilities.
+#[derive(Debug)]
+pub struct Initialized;
+
+impl Notification for Initialized {
+    type Params = ();
+    const METHOD: &'static str = NOTIFICATION__Initialized;
+}
+
 pub const NOTIFICATION__Initialized: &'static str = "initialized";
+
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct InitializeParams {
@@ -990,12 +1020,29 @@ pub const REQUEST__Shutdown: &'static str = "shutdown";
  * The server should exit with success code 0 if the shutdown request has been received before;
  * otherwise with error code 1.
  */
+#[derive(Debug)]
+pub struct Exit;
+
+impl Notification for Exit {
+    type Params = ();
+    const METHOD: &'static str = NOTIFICATION__Exit;
+}
+
 pub const NOTIFICATION__Exit: &'static str = "exit";
+
 
 /**
  * The show message notification is sent from a server to a client to ask the client to display a particular message
  * in the user interface.
  */
+#[derive(Debug)]
+pub struct ShowMessage;
+
+impl Notification for ShowMessage {
+    type Params = ShowMessageParams;
+    const METHOD: &'static str = NOTIFICATION__ShowMessage;
+}
+
 pub const NOTIFICATION__ShowMessage: &'static str = "window/showMessage";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1080,6 +1127,14 @@ pub struct MessageActionItem {
 /**
  * The log message notification is sent from the server to the client to ask the client to log a particular message.
  */
+#[derive(Debug)]
+pub struct LogMessage;
+
+impl Notification for LogMessage {
+    type Params = LogMessageParams;
+    const METHOD: &'static str = NOTIFICATION__LogMessage;
+}
+
 pub const NOTIFICATION__LogMessage: &'static str = "window/logMessage";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1095,16 +1150,32 @@ pub struct LogMessageParams {
 /**
  * The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
  */
+#[derive(Debug)]
+pub struct TelemetryEvent;
+
+impl Notification for TelemetryEvent {
+    type Params = ();
+    const METHOD: &'static str = NOTIFICATION__TelemetryEvent;
+}
+
 pub const NOTIFICATION__TelemetryEvent: &'static str = "telemetry/event";
 
 
 /**
  * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
  */
+#[derive(Debug)]
+pub struct RegisterCapability;
+
+impl Notification for RegisterCapability {
+    type Params = RegistrationParams;
+    const METHOD: &'static str = NOTIFICATION__RegisterCapability;
+}
+
 pub const NOTIFICATION__RegisterCapability: &'static str = "client/registerCapability";
 
 /**
- * General paramters to to regsiter for a capability.
+ * General parameters to to register for a capability.
  */
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Registration {
@@ -1145,6 +1216,14 @@ pub struct TextDocumentRegistrationOptions {
 
 /// The client/unregisterCapability request is sent from the server to the client to unregister a
 /// previously register capability.
+#[derive(Debug)]
+pub struct UnregisterCapability;
+
+impl Notification for UnregisterCapability {
+    type Params = UnregistrationParams;
+    const METHOD: &'static str = NOTIFICATION__UnregisterCapability;
+}
+
 pub const NOTIFICATION__UnregisterCapability: &'static str = "client/unregisterCapability";
 
 /**
@@ -1172,6 +1251,14 @@ pub struct UnregistrationParams {
 /**
  * A notification sent from the client to the server to signal the change of configuration settings.
  */
+#[derive(Debug)]
+pub struct DidChangeConfiguration;
+
+impl Notification for DidChangeConfiguration {
+    type Params = DidChangeConfigurationParams;
+    const METHOD: &'static str = NOTIFICATION__WorkspaceChangeConfiguration;
+}
+
 pub const NOTIFICATION__WorkspaceChangeConfiguration: &'static str = "workspace/didChangeConfiguration";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -1185,6 +1272,14 @@ pub struct DidChangeConfigurationParams {
  * The document's truth is now managed by the client and the server must not try to read the document's truth
  * using the document's uri.
  */
+#[derive(Debug)]
+pub struct DidOpenTextDocument;
+
+impl Notification for DidOpenTextDocument {
+    type Params = DidOpenTextDocumentParams;
+    const METHOD: &'static str = NOTIFICATION__DidOpenTextDocument;
+}
+
 pub const NOTIFICATION__DidOpenTextDocument: &'static str = "textDocument/didOpen";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1198,6 +1293,14 @@ pub struct DidOpenTextDocumentParams {
  * The document change notification is sent from the client to the server to signal changes to a text document.
  * In 2.0 the shape of the params has changed to include proper version numbers and language ids.
  */
+#[derive(Debug)]
+pub struct DidChangeTextDocument;
+
+impl Notification for DidChangeTextDocument {
+    type Params = DidChangeTextDocumentParams;
+    const METHOD: &'static str = NOTIFICATION__DidChangeTextDocument;
+}
+
 pub const NOTIFICATION__DidChangeTextDocument: &'static str = "textDocument/didChange";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1252,6 +1355,14 @@ pub struct TextDocumentChangeRegistrationOptions {
 
 /// The document will save notification is sent from the client to the server before the document
 /// is actually saved.
+#[derive(Debug)]
+pub struct WillSave;
+
+impl Notification for WillSave {
+    type Params = ();
+    const METHOD: &'static str = NOTIFICATION__WillSave;
+}
+
 pub const NOTIFICATION__WillSave: &'static str = "textDocument/willSave";
 
 /// The document will save request is sent from the client to the server before the document is
@@ -1259,6 +1370,14 @@ pub const NOTIFICATION__WillSave: &'static str = "textDocument/willSave";
 /// document before it is saved. Please note that clients might drop results if computing the text
 /// edits took too long or if a server constantly fails on this request. This is done to keep the
 /// save fast and reliable.
+#[derive(Debug)]
+pub struct WillSaveWaitUntil;
+
+impl Notification for WillSaveWaitUntil {
+    type Params = ();
+    const METHOD: &'static str = NOTIFICATION__WillSaveWaitUntil;
+}
+
 pub const NOTIFICATION__WillSaveWaitUntil: &'static str = "textDocument/willSaveWaitUntil";
 
 /**
@@ -1334,6 +1453,14 @@ impl serde::Serialize for TextDocumentSaveReason {
  * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri
  * the truth now exists on disk).
  */
+#[derive(Debug)]
+pub struct DidCloseTextDocument;
+
+impl Notification for DidCloseTextDocument {
+    type Params = DidCloseTextDocumentParams;
+    const METHOD: &'static str = NOTIFICATION__DidCloseTextDocument;
+}
+
 pub const NOTIFICATION__DidCloseTextDocument: &'static str = "textDocument/didClose";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1346,6 +1473,14 @@ pub struct DidCloseTextDocumentParams {
 /**
  * The document save notification is sent from the client to the server when the document was saved in the client.
  */
+#[derive(Debug)]
+pub struct DidSaveTextDocument;
+
+impl Notification for DidSaveTextDocument {
+    type Params = DidSaveTextDocumentParams;
+    const METHOD: &'static str = NOTIFICATION__DidSaveTextDocument;
+}
+
 pub const NOTIFICATION__DidSaveTextDocument: &'static str = "textDocument/didSave";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1359,6 +1494,14 @@ pub struct DidSaveTextDocumentParams {
  * The watched files notification is sent from the client to the server when the client detects changes to files
  * watched by the language client.
  */
+#[derive(Debug)]
+pub struct DidChangeWatchedFiles;
+
+impl Notification for DidChangeWatchedFiles {
+    type Params = DidChangeWatchedFilesParams;
+    const METHOD: &'static str = NOTIFICATION__DidChangeWatchedFiles;
+}
+
 pub const NOTIFICATION__DidChangeWatchedFiles: &'static str = "workspace/didChangeWatchedFiles";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -1429,6 +1572,14 @@ impl FileEvent {
 /**
  * Diagnostics notification are sent from the server to the client to signal results of validation runs.
  */
+#[derive(Debug)]
+pub struct PublishDiagnostics;
+
+impl Notification for PublishDiagnostics {
+    type Params = PublishDiagnosticsParams;
+    const METHOD: &'static str = NOTIFICATION__PublishDiagnostics;
+}
+
 pub const NOTIFICATION__PublishDiagnostics: &'static str = "textDocument/publishDiagnostics";
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,0 +1,208 @@
+use super::*;
+
+pub trait Notification {
+    type Params;
+    const METHOD: &'static str;
+}
+
+/// The base protocol now offers support for request cancellation. To cancel a request,
+/// a notification message with the following properties is sent:
+///
+/// A request that got canceled still needs to return from the server and send a response back.
+/// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
+/// that every request sends a response back. In addition it allows for returning partial results on cancel.
+#[derive(Debug)]
+pub enum Cancel { }
+
+impl Notification for Cancel {
+    type Params = CancelParams;
+    const METHOD: &'static str = "$/cancelRequest";
+}
+
+/// The initialized notification is sent from the client to the server after the client received
+/// the result of the initialize request but before the client is sending any other request or
+/// notification to the server. The server can use the initialized notification for example to
+/// dynamically register capabilities.
+#[derive(Debug)]
+pub enum Initialized { }
+
+impl Notification for Initialized {
+    type Params = ();
+    const METHOD: &'static str = "initialized";
+}
+
+/**
+ * A notification to ask the server to exit its process.
+ * The server should exit with success code 0 if the shutdown request has been received before;
+ * otherwise with error code 1.
+ */
+#[derive(Debug)]
+pub enum Exit { }
+
+impl Notification for Exit {
+    type Params = ();
+    const METHOD: &'static str = "exit";
+}
+
+/**
+ * The show message notification is sent from a server to a client to ask the client to display a particular message
+ * in the user interface.
+ */
+#[derive(Debug)]
+pub enum ShowMessage { }
+
+impl Notification for ShowMessage {
+    type Params = ShowMessageParams;
+    const METHOD: &'static str = "window/showMessage";
+}
+
+/**
+ * The log message notification is sent from the server to the client to ask the client to log a particular message.
+ */
+#[derive(Debug)]
+pub enum LogMessage { }
+
+impl Notification for LogMessage {
+    type Params = LogMessageParams;
+    const METHOD: &'static str = "window/logMessage";
+}
+
+/**
+ * The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
+ */
+#[derive(Debug)]
+pub enum TelemetryEvent { }
+
+impl Notification for TelemetryEvent {
+    type Params = ();
+    const METHOD: &'static str = "telemetry/event";
+}
+
+/**
+ * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
+ */
+#[derive(Debug)]
+pub enum RegisterCapability { }
+
+impl Notification for RegisterCapability {
+    type Params = RegistrationParams;
+    const METHOD: &'static str = "client/registerCapability";
+}
+
+
+/// The client/unregisterCapability request is sent from the server to the client to unregister a
+/// previously register capability.
+#[derive(Debug)]
+pub enum UnregisterCapability { }
+
+impl Notification for UnregisterCapability {
+    type Params = UnregistrationParams;
+    const METHOD: &'static str = "client/unregisterCapability";
+}
+
+/**
+ * A notification sent from the client to the server to signal the change of configuration settings.
+ */
+#[derive(Debug)]
+pub enum DidChangeConfiguration { }
+
+impl Notification for DidChangeConfiguration {
+    type Params = DidChangeConfigurationParams;
+    const METHOD: &'static str = "workspace/didChangeConfiguration";
+}
+
+/**
+ * The document open notification is sent from the client to the server to signal newly opened text documents.
+ * The document's truth is now managed by the client and the server must not try to read the document's truth
+ * using the document's uri.
+ */
+#[derive(Debug)]
+pub enum DidOpenTextDocument { }
+
+impl Notification for DidOpenTextDocument {
+    type Params = DidOpenTextDocumentParams;
+    const METHOD: &'static str = "textDocument/didOpen";
+}
+
+/**
+ * The document change notification is sent from the client to the server to signal changes to a text document.
+ * In 2.0 the shape of the params has changed to include proper version numbers and language ids.
+ */
+#[derive(Debug)]
+pub enum DidChangeTextDocument { }
+
+impl Notification for DidChangeTextDocument {
+    type Params = DidChangeTextDocumentParams;
+    const METHOD: &'static str = "textDocument/didChange";
+}
+
+/// The document will save notification is sent from the client to the server before the document
+/// is actually saved.
+#[derive(Debug)]
+pub enum WillSave { }
+
+impl Notification for WillSave {
+    type Params = ();
+    const METHOD: &'static str = "textDocument/willSave";
+}
+
+/// The document will save request is sent from the client to the server before the document is
+/// actually saved. The request can return an array of TextEdits which will be applied to the text
+/// document before it is saved. Please note that clients might drop results if computing the text
+/// edits took too long or if a server constantly fails on this request. This is done to keep the
+/// save fast and reliable.
+#[derive(Debug)]
+pub enum WillSaveWaitUntil { }
+
+impl Notification for WillSaveWaitUntil {
+    type Params = ();
+    const METHOD: &'static str = "textDocument/willSaveWaitUntil";
+}
+
+
+/**
+ * The document close notification is sent from the client to the server when the document got closed in the client.
+ * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri
+ * the truth now exists on disk).
+ */
+#[derive(Debug)]
+pub enum DidCloseTextDocument { }
+
+impl Notification for DidCloseTextDocument {
+    type Params = DidCloseTextDocumentParams;
+    const METHOD: &'static str = "textDocument/didClose";
+}
+
+/**
+ * The document save notification is sent from the client to the server when the document was saved in the client.
+ */
+#[derive(Debug)]
+pub enum DidSaveTextDocument { }
+
+impl Notification for DidSaveTextDocument {
+    type Params = DidSaveTextDocumentParams;
+    const METHOD: &'static str = "textDocument/didSave";
+}
+
+/**
+ * The watched files notification is sent from the client to the server when the client detects changes to files
+ * watched by the language client.
+ */
+#[derive(Debug)]
+pub enum DidChangeWatchedFiles { }
+
+impl Notification for DidChangeWatchedFiles {
+    type Params = DidChangeWatchedFilesParams;
+    const METHOD: &'static str = "workspace/didChangeWatchedFiles";
+}
+
+/**
+ * Diagnostics notification are sent from the server to the client to signal results of validation runs.
+ */
+#[derive(Debug)]
+pub enum PublishDiagnostics { }
+
+impl Notification for PublishDiagnostics {
+    type Params = PublishDiagnosticsParams;
+    const METHOD: &'static str = "textDocument/publishDiagnostics";
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -66,7 +66,7 @@ impl Request for ShowMessageRequest {
 pub enum Completion { }
 
 impl Request for Completion {
-    type Params = TextDocumentPositionParams; // TODO: extend with CompletionContext as CompletionParams
+    type Params = CompletionParams;
     type Result = CompletionResponse;
     const METHOD: &'static str = "textDocument/completion";
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,311 @@
+use super::*;
+
+pub trait Request {
+    type Params;
+    type Result;
+    const METHOD: &'static str;
+}
+
+/**
+
+ The initialize request is sent as the first request from the client to the server.
+ If the server receives request or notification before the `initialize` request it should act as follows:
+
+ * for a request the respond should be errored with `code: -32001`. The message can be picked by the server.
+ * notifications should be dropped.
+
+*/
+#[derive(Debug)]
+pub enum Initialize { }
+
+impl Request for Initialize {
+    type Params = InitializeParams;
+    type Result = InitializeResult;
+    const METHOD: &'static str = "initialize";
+}
+
+/**
+ * The shutdown request is sent from the client to the server. It asks the server to shut down,
+ * but to not exit (otherwise the response might not be delivered correctly to the client).
+ * There is a separate exit notification that asks the server to exit.
+ */
+#[derive(Debug)]
+pub enum Shutdown { }
+
+impl Request for Shutdown {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = "shutdown";
+}
+
+/**
+ * The show message request is sent from a server to a client to ask the client to display a particular message
+ * in the user interface. In addition to the show message notification the request allows to pass actions and to
+ * wait for an answer from the client.
+ */
+#[derive(Debug)]
+pub enum ShowMessageRequest { }
+
+impl Request for ShowMessageRequest {
+    type Params = ShowMessageRequestParams;
+    type Result = Option<MessageActionItem>;
+    const METHOD: &'static str = "window/showMessageRequest";
+}
+
+/**
+ The Completion request is sent from the client to the server to compute completion items at a given cursor position.
+ Completion items are presented in the IntelliSense user interface. If computing full completion items is expensive,
+ servers can additionally provide a handler for the completion item resolve request ('completionItem/resolve').
+ This request is sent when a completion item is selected in the user interface. A typically use case is for example:
+ the 'textDocument/completion' request doesn't fill in the documentation property for returned completion items
+ since it is expensive to compute. When the item is selected in the user interface then a 'completionItem/resolve'
+ request is sent with the selected completion item as a param. The returned completion item should have the
+ documentation property filled in.
+*/
+#[derive(Debug)]
+pub enum Completion { }
+
+impl Request for Completion {
+    type Params = TextDocumentPositionParams; // TODO: extend with CompletionContext as CompletionParams
+    type Result = CompletionResponse;
+    const METHOD: &'static str = "textDocument/completion";
+}
+
+/// The request is sent from the client to the server to resolve additional information for a given completion item.
+#[derive(Debug)]
+pub enum ResolveCompletionItem { }
+
+impl Request for ResolveCompletionItem {
+    type Params = CompletionItem;
+    type Result = CompletionItem;
+    const METHOD: &'static str = "completionItem/resolve";
+}
+
+/// The hover request is sent from the client to the server to request hover information at a given text
+/// document position.
+#[derive(Debug)]
+pub enum HoverRequest { }
+
+impl Request for HoverRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<Hover>;
+    const METHOD: &'static str = "textDocument/hover";
+}
+
+/// The signature help request is sent from the client to the server to request signature information at
+/// a given cursor position.
+#[derive(Debug)]
+pub enum SignatureHelpRequest { }
+
+impl Request for SignatureHelpRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<SignatureHelp>;
+    const METHOD: &'static str = "textDocument/signatureHelp";
+}
+
+/// The goto definition request is sent from the client to the server to resolve the definition location of
+/// a symbol at a given text document position.
+#[derive(Debug)]
+pub enum GotoDefinition { }
+
+impl Request for GotoDefinition {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<GotoDefinitionResponse>;
+    const METHOD: &'static str = "textDocument/definition";
+}
+
+/**
+ * GotoDefinition response can be single location or multiple ones.
+ */
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GotoDefinitionResponse {
+    Scalar(Location),
+    Array(Vec<Location>),
+}
+
+/// The references request is sent from the client to the server to resolve project-wide references for the
+/// symbol denoted by the given text document position.
+pub enum References { }
+
+impl Request for References {
+    type Params = ReferenceParams;
+    type Result = Option<Vec<Location>>;
+    const METHOD: &'static str = "textDocument/references";
+}
+
+/**
+ The document highlight request is sent from the client to the server to resolve a document highlights
+ for a given text document position.
+ For programming languages this usually highlights all references to the symbol scoped to this file.
+ However we kept 'textDocument/documentHighlight' and 'textDocument/references' separate requests since
+ the first one is allowed to be more fuzzy.
+ Symbol matches usually have a DocumentHighlightKind of Read or Write whereas fuzzy or textual matches
+ use Textas the kind.
+*/
+#[derive(Debug)]
+pub enum DocumentHighlightRequest { }
+
+impl Request for DocumentHighlightRequest {
+    type Params = TextDocumentPositionParams;
+    type Result = Option<Vec<DocumentHighlight>>;
+    const METHOD: &'static str = "textDocument/documentHighlight";
+}
+
+/**
+ * The document symbol request is sent from the client to the server to list all symbols found in a given
+ * text document.
+ */
+#[derive(Debug)]
+pub enum DocumentSymbol { }
+
+impl Request for DocumentSymbol {
+    type Params = DocumentSymbolParams;
+    type Result = Option<Vec<SymbolInformation>>;
+    const METHOD: &'static str = "textDocument/documentSymbol";
+}
+
+/**
+ * The workspace symbol request is sent from the client to the server to list project-wide symbols
+ * matching the query string.
+ */
+#[derive(Debug)]
+pub enum WorkspaceSymbol { }
+
+impl Request for WorkspaceSymbol {
+    type Params = WorkspaceSymbolParams;
+    type Result = Option<Vec<SymbolInformation>>;
+    const METHOD: &'static str = "workspace/symbol";
+}
+
+/// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server. In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request workspace/applyEdit which is sent from the server to the client.
+#[derive(Debug)]
+pub enum ExecuteCommand { }
+
+impl Request for ExecuteCommand {
+    type Params = ExecuteCommandParams;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "workspace/executeCommand";
+}
+
+/// The workspace/applyEdit request is sent from the server to the client to modify resource on the
+/// client side.
+#[derive(Debug)]
+pub enum ApplyWorkspaceEdit { }
+
+impl Request for ApplyWorkspaceEdit {
+    type Params = ApplyWorkspaceEditParams;
+    type Result = ApplyWorkspaceEditResponse;
+    const METHOD: &'static str = "workspace/applyEdit";
+}
+
+/**
+ * The code action request is sent from the client to the server to compute commands for a given text document
+ * and range. The request is triggered when the user moves the cursor into a problem marker in the editor or
+ * presses the lightbulb associated with a marker.
+ */
+#[derive(Debug)]
+pub enum CodeActionRequest { }
+
+impl Request for CodeActionRequest {
+    type Params = CodeActionParams;
+    type Result = Option<Vec<Command>>;
+    const METHOD: &'static str = "textDocument/codeAction";
+}
+
+/**
+ * The code lens request is sent from the client to the server to compute code lenses for a given text document.
+ */
+#[derive(Debug)]
+pub enum CodeLensRequest { }
+
+impl Request for CodeLensRequest {
+    type Params = CodeLensParams;
+    type Result = Option<Vec<CodeLens>>;
+    const METHOD: &'static str = "textDocument/codeLens";
+}
+
+/**
+ * The code lens resolve request is sent from the client to the server to resolve the command for a
+ * given code lens item.
+ */
+#[derive(Debug)]
+pub enum CodeLensResolve { }
+
+impl Request for CodeLensResolve {
+    type Params = CodeLens;
+    type Result = CodeLens;
+    const METHOD: &'static str = "codeLens/resolve";
+}
+
+/// The document links request is sent from the client to the server to request the location of links in a document.
+#[derive(Debug)]
+pub enum DocumentLinkRequest { }
+
+impl Request for DocumentLinkRequest {
+    type Params = DocumentLinkParams;
+    type Result = Option<Vec<DocumentLink>>;
+    const METHOD: &'static str = "textDocument/documentLink";
+}
+
+/**
+
+ The document link resolve request is sent from the client to the server to resolve the target of
+ a given document link.
+
+*/
+#[derive(Debug)]
+pub enum DocumentLinkResolve { }
+
+impl Request for DocumentLinkResolve {
+    type Params = DocumentLink;
+    type Result = DocumentLink;
+    const METHOD: &'static str = "documentLink/resolve";
+}
+
+/**
+ * The document formatting request is sent from the server to the client to format a whole document.
+ */
+#[derive(Debug)]
+pub enum Formatting { }
+
+impl Request for Formatting {
+    type Params = DocumentFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = "textDocument/formatting";
+}
+
+/// The document range formatting request is sent from the client to the server to format a given range in a document.
+#[derive(Debug)]
+pub enum RangeFormatting { }
+
+impl Request for RangeFormatting {
+    type Params = DocumentRangeFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = "textDocument/rangeFormatting";
+}
+
+/**
+ * The document on type formatting request is sent from the client to the server to format parts of
+ * the document during typing.
+ */
+#[derive(Debug)]
+pub enum OnTypeFormatting { }
+
+impl Request for OnTypeFormatting {
+    type Params = DocumentOnTypeFormattingParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = "textDocument/onTypeFormatting";
+}
+
+/**
+ * The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
+ */
+#[derive(Debug)]
+pub enum Rename { }
+
+impl Request for Rename {
+    type Params = RenameParams;
+    type Result = Option<WorkspaceEdit>;
+    const METHOD: &'static str = "textDocument/rename";
+}


### PR DESCRIPTION
Attempt at #19. I took some sweet time with this, sorry for doing it so late.

Currently LSP spec provides new `CompletionParams` and `CompletionContext` types to be used with Completion Request, so I used LSP commit in the comment and used [`TextDocumentPositionParams`](https://github.com/gluon-lang/languageserver-types/compare/master...Xanewok:message-traits?expand=1#diff-b4aea3e418ccdb71239b96952d9cddb6R1643) as param type instead.

@Marwes does this align with what you wanted in #19?