### PR TITLE
 feat: Add macros which map from RPC method strings to the RPC traits 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "languageserver-types"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Bruno Medeiros <bruno.do.medeiros@gmail.com>"]
 
 description = "Types for interaction with a language server, using VSCode's Language Server Protocol"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ such as `urn:isbn:0451450523`.
 #[macro_use]
 extern crate enum_primitive;
 extern crate serde;
-extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 
 extern crate url;
 extern crate url_serde;
@@ -102,8 +102,7 @@ impl Range {
 /// Represents a location inside a resource, such as a line inside a text file.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct Location {
-    #[serde(with = "url_serde")]
-    pub uri: Url,
+    #[serde(with = "url_serde")] pub uri: Url,
     pub range: Range,
 }
 
@@ -503,12 +502,9 @@ pub struct InitializeParams {
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TraceOption {
-    #[serde(rename = "off")]
-    Off,
-    #[serde(rename = "messages")]
-    Messages,
-    #[serde(rename = "verbose")]
-    Verbose,
+    #[serde(rename = "off")] Off,
+    #[serde(rename = "messages")] Messages,
+    #[serde(rename = "verbose")] Verbose,
 }
 
 impl Default for TraceOption {
@@ -1346,25 +1342,24 @@ pub struct CompletionParams {
     pub position: Position,
 
     // CompletionParams properties:
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub context: Option<CompletionContext>,
+    #[serde(skip_serializing_if = "Option::is_none")] pub context: Option<CompletionContext>,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct CompletionContext {
-	/**
-	 * How the completion was triggered.
-	 */
-     #[serde(rename = "triggerKind")]
-	pub trigger_kind: CompletionTriggerKind,
+    /**
+     * How the completion was triggered.
+     */
+    #[serde(rename = "triggerKind")]
+    pub trigger_kind: CompletionTriggerKind,
 
-	/**
-	 * The trigger character (a single character) that has trigger code complete.
-	 * Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
-	 */
-     #[serde(rename = "triggerCharacter")]
-     #[serde(skip_serializing_if = "Option::is_none")]
-	pub trigger_character: Option<String>,
+    /**
+     * The trigger character (a single character) that has trigger code complete.
+     * Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+     */
+    #[serde(rename = "triggerCharacter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_character: Option<String>,
 }
 
 enum_from_primitive!{
@@ -2037,10 +2032,9 @@ impl<'de> serde::Deserialize<'de> for FormattingOptions {
                     }
                     properties.insert(key.into_owned(), map.next_value()?);
                 }
-                let tab_size = tab_size
-                    .ok_or_else(|| de::Error::missing_field("tab_size"))?;
-                let insert_spaces = insert_spaces
-                    .ok_or_else(|| de::Error::missing_field("insert_spaces"))?;
+                let tab_size = tab_size.ok_or_else(|| de::Error::missing_field("tab_size"))?;
+                let insert_spaces =
+                    insert_spaces.ok_or_else(|| de::Error::missing_field("insert_spaces"))?;
                 Ok(FormattingOptions {
                     tab_size: tab_size,
                     insert_spaces: insert_spaces,
@@ -2156,7 +2150,6 @@ mod tests {
 
     #[test]
     fn number_or_string() {
-
         test_serialization(&NumberOrString::Number(123), r#"123"#);
 
         test_serialization(&NumberOrString::String("abcd".into()), r#""abcd""#);
@@ -2164,7 +2157,6 @@ mod tests {
 
     #[test]
     fn marked_string() {
-
         test_serialization(&MarkedString::from_markdown("xxx".into()), r#""xxx""#);
 
         test_serialization(

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -16,8 +16,8 @@ macro_rules! lsp_notification {
 
     ("telemetry/event") => { $crate::notification::Event };
 
-    ("client/registerCapability") => { $crate::notification::RegistrationParams };
-    ("client/unregisterCapability") => { $crate::notification::UnregistrationParams };
+    ("client/registerCapability") => { $crate::notification::RegisterCapability };
+    ("client/unregisterCapability") => { $crate::notification::UnregisterCapability };
 
     ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocument };
     ("textDocument/didChange") => { $crate::notification::DidChangeTextDocument };

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -5,6 +5,32 @@ pub trait Notification {
     const METHOD: &'static str;
 }
 
+#[macro_export]
+macro_rules! lsp_notification {
+    ("$/cancelRequest") => { $crate::notification::Cancel };
+    ("initialized") => { $crate::notification::Initialized };
+    ("exit") => { $crate::notification::Exit };
+
+    ("window/showMessage") => { $crate::notification::ShowMessage };
+    ("window/logMessage") => { $crate::notification::LogMessage };
+
+    ("telemetry/event") => { $crate::notification::Event };
+
+    ("client/registerCapability") => { $crate::notification::RegistrationParams };
+    ("client/unregisterCapability") => { $crate::notification::UnregistrationParams };
+
+    ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocument };
+    ("textDocument/didChange") => { $crate::notification::DidChangeTextDocument };
+    ("textDocument/willSave") => { $crate::notification::WillSaveTextDocument };
+    ("textDocument/didSave") => { $crate::notification::DidSaveTextDocument };
+    ("textDocument/didClose") => { $crate::notification::DidCloseTextDocument };
+    ("textDocument/publishDiagnostics") => { $crate::notification::PublishDiagnostics };
+
+    ("workspace/didChangeConfiguration") => { $crate::notification::DidChangeConfiguration };
+    ("workspace/didChangeWatchedFiles") => { $crate::notification::DidChangeWatchedFiles };
+}
+
+
 /// The base protocol now offers support for request cancellation. To cancel a request,
 /// a notification message with the following properties is sent:
 ///

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -12,7 +12,7 @@ pub trait Notification {
 /// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
 /// that every request sends a response back. In addition it allows for returning partial results on cancel.
 #[derive(Debug)]
-pub enum Cancel { }
+pub enum Cancel {}
 
 impl Notification for Cancel {
     type Params = CancelParams;
@@ -24,7 +24,7 @@ impl Notification for Cancel {
 /// notification to the server. The server can use the initialized notification for example to
 /// dynamically register capabilities.
 #[derive(Debug)]
-pub enum Initialized { }
+pub enum Initialized {}
 
 impl Notification for Initialized {
     type Params = ();
@@ -37,7 +37,7 @@ impl Notification for Initialized {
  * otherwise with error code 1.
  */
 #[derive(Debug)]
-pub enum Exit { }
+pub enum Exit {}
 
 impl Notification for Exit {
     type Params = ();
@@ -49,7 +49,7 @@ impl Notification for Exit {
  * in the user interface.
  */
 #[derive(Debug)]
-pub enum ShowMessage { }
+pub enum ShowMessage {}
 
 impl Notification for ShowMessage {
     type Params = ShowMessageParams;
@@ -60,7 +60,7 @@ impl Notification for ShowMessage {
  * The log message notification is sent from the server to the client to ask the client to log a particular message.
  */
 #[derive(Debug)]
-pub enum LogMessage { }
+pub enum LogMessage {}
 
 impl Notification for LogMessage {
     type Params = LogMessageParams;
@@ -71,7 +71,7 @@ impl Notification for LogMessage {
  * The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
  */
 #[derive(Debug)]
-pub enum TelemetryEvent { }
+pub enum TelemetryEvent {}
 
 impl Notification for TelemetryEvent {
     type Params = ();
@@ -82,7 +82,7 @@ impl Notification for TelemetryEvent {
  * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
  */
 #[derive(Debug)]
-pub enum RegisterCapability { }
+pub enum RegisterCapability {}
 
 impl Notification for RegisterCapability {
     type Params = RegistrationParams;
@@ -93,7 +93,7 @@ impl Notification for RegisterCapability {
 /// The client/unregisterCapability request is sent from the server to the client to unregister a
 /// previously register capability.
 #[derive(Debug)]
-pub enum UnregisterCapability { }
+pub enum UnregisterCapability {}
 
 impl Notification for UnregisterCapability {
     type Params = UnregistrationParams;
@@ -104,7 +104,7 @@ impl Notification for UnregisterCapability {
  * A notification sent from the client to the server to signal the change of configuration settings.
  */
 #[derive(Debug)]
-pub enum DidChangeConfiguration { }
+pub enum DidChangeConfiguration {}
 
 impl Notification for DidChangeConfiguration {
     type Params = DidChangeConfigurationParams;
@@ -117,7 +117,7 @@ impl Notification for DidChangeConfiguration {
  * using the document's uri.
  */
 #[derive(Debug)]
-pub enum DidOpenTextDocument { }
+pub enum DidOpenTextDocument {}
 
 impl Notification for DidOpenTextDocument {
     type Params = DidOpenTextDocumentParams;
@@ -129,7 +129,7 @@ impl Notification for DidOpenTextDocument {
  * In 2.0 the shape of the params has changed to include proper version numbers and language ids.
  */
 #[derive(Debug)]
-pub enum DidChangeTextDocument { }
+pub enum DidChangeTextDocument {}
 
 impl Notification for DidChangeTextDocument {
     type Params = DidChangeTextDocumentParams;
@@ -139,7 +139,7 @@ impl Notification for DidChangeTextDocument {
 /// The document will save notification is sent from the client to the server before the document
 /// is actually saved.
 #[derive(Debug)]
-pub enum WillSave { }
+pub enum WillSave {}
 
 impl Notification for WillSave {
     type Params = ();
@@ -152,7 +152,7 @@ impl Notification for WillSave {
 /// edits took too long or if a server constantly fails on this request. This is done to keep the
 /// save fast and reliable.
 #[derive(Debug)]
-pub enum WillSaveWaitUntil { }
+pub enum WillSaveWaitUntil {}
 
 impl Notification for WillSaveWaitUntil {
     type Params = ();
@@ -166,7 +166,7 @@ impl Notification for WillSaveWaitUntil {
  * the truth now exists on disk).
  */
 #[derive(Debug)]
-pub enum DidCloseTextDocument { }
+pub enum DidCloseTextDocument {}
 
 impl Notification for DidCloseTextDocument {
     type Params = DidCloseTextDocumentParams;
@@ -177,7 +177,7 @@ impl Notification for DidCloseTextDocument {
  * The document save notification is sent from the client to the server when the document was saved in the client.
  */
 #[derive(Debug)]
-pub enum DidSaveTextDocument { }
+pub enum DidSaveTextDocument {}
 
 impl Notification for DidSaveTextDocument {
     type Params = DidSaveTextDocumentParams;
@@ -189,7 +189,7 @@ impl Notification for DidSaveTextDocument {
  * watched by the language client.
  */
 #[derive(Debug)]
-pub enum DidChangeWatchedFiles { }
+pub enum DidChangeWatchedFiles {}
 
 impl Notification for DidChangeWatchedFiles {
     type Params = DidChangeWatchedFilesParams;
@@ -200,7 +200,7 @@ impl Notification for DidChangeWatchedFiles {
  * Diagnostics notification are sent from the server to the client to signal results of validation runs.
  */
 #[derive(Debug)]
-pub enum PublishDiagnostics { }
+pub enum PublishDiagnostics {}
 
 impl Notification for PublishDiagnostics {
     type Params = PublishDiagnosticsParams;

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,7 +16,7 @@ pub trait Request {
 
 */
 #[derive(Debug)]
-pub enum Initialize { }
+pub enum Initialize {}
 
 impl Request for Initialize {
     type Params = InitializeParams;
@@ -30,7 +30,7 @@ impl Request for Initialize {
  * There is a separate exit notification that asks the server to exit.
  */
 #[derive(Debug)]
-pub enum Shutdown { }
+pub enum Shutdown {}
 
 impl Request for Shutdown {
     type Params = ();
@@ -44,7 +44,7 @@ impl Request for Shutdown {
  * wait for an answer from the client.
  */
 #[derive(Debug)]
-pub enum ShowMessageRequest { }
+pub enum ShowMessageRequest {}
 
 impl Request for ShowMessageRequest {
     type Params = ShowMessageRequestParams;
@@ -63,7 +63,7 @@ impl Request for ShowMessageRequest {
  documentation property filled in.
 */
 #[derive(Debug)]
-pub enum Completion { }
+pub enum Completion {}
 
 impl Request for Completion {
     type Params = CompletionParams;
@@ -73,7 +73,7 @@ impl Request for Completion {
 
 /// The request is sent from the client to the server to resolve additional information for a given completion item.
 #[derive(Debug)]
-pub enum ResolveCompletionItem { }
+pub enum ResolveCompletionItem {}
 
 impl Request for ResolveCompletionItem {
     type Params = CompletionItem;
@@ -84,7 +84,7 @@ impl Request for ResolveCompletionItem {
 /// The hover request is sent from the client to the server to request hover information at a given text
 /// document position.
 #[derive(Debug)]
-pub enum HoverRequest { }
+pub enum HoverRequest {}
 
 impl Request for HoverRequest {
     type Params = TextDocumentPositionParams;
@@ -95,7 +95,7 @@ impl Request for HoverRequest {
 /// The signature help request is sent from the client to the server to request signature information at
 /// a given cursor position.
 #[derive(Debug)]
-pub enum SignatureHelpRequest { }
+pub enum SignatureHelpRequest {}
 
 impl Request for SignatureHelpRequest {
     type Params = TextDocumentPositionParams;
@@ -106,7 +106,7 @@ impl Request for SignatureHelpRequest {
 /// The goto definition request is sent from the client to the server to resolve the definition location of
 /// a symbol at a given text document position.
 #[derive(Debug)]
-pub enum GotoDefinition { }
+pub enum GotoDefinition {}
 
 impl Request for GotoDefinition {
     type Params = TextDocumentPositionParams;
@@ -126,7 +126,7 @@ pub enum GotoDefinitionResponse {
 
 /// The references request is sent from the client to the server to resolve project-wide references for the
 /// symbol denoted by the given text document position.
-pub enum References { }
+pub enum References {}
 
 impl Request for References {
     type Params = ReferenceParams;
@@ -144,7 +144,7 @@ impl Request for References {
  use Textas the kind.
 */
 #[derive(Debug)]
-pub enum DocumentHighlightRequest { }
+pub enum DocumentHighlightRequest {}
 
 impl Request for DocumentHighlightRequest {
     type Params = TextDocumentPositionParams;
@@ -157,7 +157,7 @@ impl Request for DocumentHighlightRequest {
  * text document.
  */
 #[derive(Debug)]
-pub enum DocumentSymbol { }
+pub enum DocumentSymbol {}
 
 impl Request for DocumentSymbol {
     type Params = DocumentSymbolParams;
@@ -170,7 +170,7 @@ impl Request for DocumentSymbol {
  * matching the query string.
  */
 #[derive(Debug)]
-pub enum WorkspaceSymbol { }
+pub enum WorkspaceSymbol {}
 
 impl Request for WorkspaceSymbol {
     type Params = WorkspaceSymbolParams;
@@ -180,7 +180,7 @@ impl Request for WorkspaceSymbol {
 
 /// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server. In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request workspace/applyEdit which is sent from the server to the client.
 #[derive(Debug)]
-pub enum ExecuteCommand { }
+pub enum ExecuteCommand {}
 
 impl Request for ExecuteCommand {
     type Params = ExecuteCommandParams;
@@ -191,7 +191,7 @@ impl Request for ExecuteCommand {
 /// The workspace/applyEdit request is sent from the server to the client to modify resource on the
 /// client side.
 #[derive(Debug)]
-pub enum ApplyWorkspaceEdit { }
+pub enum ApplyWorkspaceEdit {}
 
 impl Request for ApplyWorkspaceEdit {
     type Params = ApplyWorkspaceEditParams;
@@ -205,7 +205,7 @@ impl Request for ApplyWorkspaceEdit {
  * presses the lightbulb associated with a marker.
  */
 #[derive(Debug)]
-pub enum CodeActionRequest { }
+pub enum CodeActionRequest {}
 
 impl Request for CodeActionRequest {
     type Params = CodeActionParams;
@@ -217,7 +217,7 @@ impl Request for CodeActionRequest {
  * The code lens request is sent from the client to the server to compute code lenses for a given text document.
  */
 #[derive(Debug)]
-pub enum CodeLensRequest { }
+pub enum CodeLensRequest {}
 
 impl Request for CodeLensRequest {
     type Params = CodeLensParams;
@@ -230,7 +230,7 @@ impl Request for CodeLensRequest {
  * given code lens item.
  */
 #[derive(Debug)]
-pub enum CodeLensResolve { }
+pub enum CodeLensResolve {}
 
 impl Request for CodeLensResolve {
     type Params = CodeLens;
@@ -240,7 +240,7 @@ impl Request for CodeLensResolve {
 
 /// The document links request is sent from the client to the server to request the location of links in a document.
 #[derive(Debug)]
-pub enum DocumentLinkRequest { }
+pub enum DocumentLinkRequest {}
 
 impl Request for DocumentLinkRequest {
     type Params = DocumentLinkParams;
@@ -255,7 +255,7 @@ impl Request for DocumentLinkRequest {
 
 */
 #[derive(Debug)]
-pub enum DocumentLinkResolve { }
+pub enum DocumentLinkResolve {}
 
 impl Request for DocumentLinkResolve {
     type Params = DocumentLink;
@@ -267,7 +267,7 @@ impl Request for DocumentLinkResolve {
  * The document formatting request is sent from the server to the client to format a whole document.
  */
 #[derive(Debug)]
-pub enum Formatting { }
+pub enum Formatting {}
 
 impl Request for Formatting {
     type Params = DocumentFormattingParams;
@@ -277,7 +277,7 @@ impl Request for Formatting {
 
 /// The document range formatting request is sent from the client to the server to format a given range in a document.
 #[derive(Debug)]
-pub enum RangeFormatting { }
+pub enum RangeFormatting {}
 
 impl Request for RangeFormatting {
     type Params = DocumentRangeFormattingParams;
@@ -290,7 +290,7 @@ impl Request for RangeFormatting {
  * the document during typing.
  */
 #[derive(Debug)]
-pub enum OnTypeFormatting { }
+pub enum OnTypeFormatting {}
 
 impl Request for OnTypeFormatting {
     type Params = DocumentOnTypeFormattingParams;
@@ -302,7 +302,7 @@ impl Request for OnTypeFormatting {
  * The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
  */
 #[derive(Debug)]
-pub enum Rename { }
+pub enum Rename {}
 
 impl Request for Rename {
     type Params = RenameParams;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,6 +6,34 @@ pub trait Request {
     const METHOD: &'static str;
 }
 
+#[macro_export]
+macro_rules! lsp_request {
+    ("initialize") => { $crate::request::Initialize };
+    ("shutdown") => { $crate::request::Shutdown };
+    ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
+    ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveWaitUntil };
+    ("textDocument/completion") => { $crate::request::Completion };
+    ("textDocument/hover") => { $crate::request::HoverRequest };
+    ("textDocument/signatureHelp") => { $crate::request::SignatureHelp };
+    ("textDocument/definition") => { $crate::request::Definition };
+    ("textDocument/references") => { $crate::request::References };
+    ("textDocument/documentHighlight") => { $crate::request::DocumentHighlightRequest };
+    ("textDocument/documentSymbol") => { $crate::request::DocumentSymbol };
+    ("textDocument/codeAction") => { $crate::request::CodeAction };
+    ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
+    ("codeLens/resolve") => { $crate::request::CodeLensResolve };
+    ("textDocument/documentLink") => { $crate::request::DocumentLink };
+    ("textDocument/applyEdit") => { $crate::request::ApplyEdit };
+    ("textDocument/rangeFormatting") => { $crate::request::RangeFormatting };
+    ("textDocument/onTypeFormatting") => { $crate::request::OnTypeFormatting };
+    ("textDocument/formatting") => { $crate::request::Formatting };
+    ("textDocument/rename") => { $crate::request::Rename };
+    ("completionItem/resolve") => { $crate::request::ResolveCompletionItem };
+    ("documentLink/resolve") => { $crate::request::DocumentLinkResolve };
+    ("workspace/symbol") => { $crate::request::WorkspaceSymbol };
+    ("workspace/executeCommand") => { $crate::request::ExecuteCommand }
+}
+
 /**
 
  The initialize request is sent as the first request from the client to the server.


### PR DESCRIPTION
Implements the mapping I hinted at in https://github.com/gluon-lang/languageserver-types/pull/29#issuecomment-347686297. The idea is that one can just grep for the actual method names that are called when searching for how/if a method is implemented instead of guessing at what a method's "type" are called.

Based on #30 

cc @Xanewok 