### PR TITLE
 fix: Allow the changes field to be omitted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "languageserver-types"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Bruno Medeiros <bruno.do.medeiros@gmail.com>"]
 
 description = "Types for interaction with a language server, using VSCode's Language Server Protocol"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,8 @@ pub struct TextDocumentEdit {
 pub struct WorkspaceEdit {
     /// Holds changes to existing resources.
     #[serde(with = "url_map")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub changes: Option<HashMap<Url, Vec<TextEdit>>>, //    changes?: { [uri: string]: TextEdit[]; };
 
     /**
@@ -2424,6 +2426,14 @@ mod tests {
                 document_changes: None,
             },
             r#"{"changes":{},"documentChanges":null}"#,
+        );
+
+        test_serialization(
+            &WorkspaceEdit {
+                changes: None,
+                document_changes: None,
+            },
+            r#"{"documentChanges":null}"#,
         );
 
         test_serialization(&WorkspaceEdit {


### PR DESCRIPTION
This is caused by using `with` for the field which causes the default
behaviour of allowing a missing fields to be transformed into `None`

Fixes #39