### PR TITLE
Move client/(un)registerCapability to requests

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -16,9 +16,6 @@ macro_rules! lsp_notification {
 
     ("telemetry/event") => { $crate::notification::Event };
 
-    ("client/registerCapability") => { $crate::notification::RegisterCapability };
-    ("client/unregisterCapability") => { $crate::notification::UnregisterCapability };
-
     ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocument };
     ("textDocument/didChange") => { $crate::notification::DidChangeTextDocument };
     ("textDocument/willSave") => { $crate::notification::WillSaveTextDocument };
@@ -101,27 +98,6 @@ pub enum TelemetryEvent {}
 impl Notification for TelemetryEvent {
     type Params = ();
     const METHOD: &'static str = "telemetry/event";
-}
-
-/**
- * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
- */
-#[derive(Debug)]
-pub enum RegisterCapability {}
-
-impl Notification for RegisterCapability {
-    type Params = RegistrationParams;
-    const METHOD: &'static str = "client/registerCapability";
-}
-
-/// The client/unregisterCapability request is sent from the server to the client to unregister a
-/// previously register capability.
-#[derive(Debug)]
-pub enum UnregisterCapability {}
-
-impl Notification for UnregisterCapability {
-    type Params = UnregistrationParams;
-    const METHOD: &'static str = "client/unregisterCapability";
 }
 
 /**

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,9 +10,18 @@ pub trait Request {
 macro_rules! lsp_request {
     ("initialize") => { $crate::request::Initialize };
     ("shutdown") => { $crate::request::Shutdown };
+
     ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
+
+    ("client/registerCapability") => { $crate::request::RegisterCapability };
+    ("client/unregisterCapability") => { $crate::request::UnregisterCapability };
+
+    ("workspace/symbol") => { $crate::request::WorkspaceSymbol };
+    ("workspace/executeCommand") => { $crate::request::ExecuteCommand };
+
     ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveWaitUntil };
     ("textDocument/completion") => { $crate::request::Completion };
+    ("completionItem/resolve") => { $crate::request::ResolveCompletionItem };
     ("textDocument/hover") => { $crate::request::HoverRequest };
     ("textDocument/signatureHelp") => { $crate::request::SignatureHelpRequest };
     ("textDocument/definition") => { $crate::request::GotoDefinition };
@@ -23,15 +32,12 @@ macro_rules! lsp_request {
     ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
     ("codeLens/resolve") => { $crate::request::CodeLensResolve };
     ("textDocument/documentLink") => { $crate::request::DocumentLink };
+    ("documentLink/resolve") => { $crate::request::DocumentLinkResolve };
     ("textDocument/applyEdit") => { $crate::request::ApplyEdit };
     ("textDocument/rangeFormatting") => { $crate::request::RangeFormatting };
     ("textDocument/onTypeFormatting") => { $crate::request::OnTypeFormatting };
     ("textDocument/formatting") => { $crate::request::Formatting };
     ("textDocument/rename") => { $crate::request::Rename };
-    ("completionItem/resolve") => { $crate::request::ResolveCompletionItem };
-    ("documentLink/resolve") => { $crate::request::DocumentLinkResolve };
-    ("workspace/symbol") => { $crate::request::WorkspaceSymbol };
-    ("workspace/executeCommand") => { $crate::request::ExecuteCommand }
 }
 
 /**
@@ -78,6 +84,29 @@ impl Request for ShowMessageRequest {
     type Params = ShowMessageRequestParams;
     type Result = Option<MessageActionItem>;
     const METHOD: &'static str = "window/showMessageRequest";
+}
+
+/**
+ * The client/registerCapability request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the ClientCapabilities.GenericCapability property.
+ */
+#[derive(Debug)]
+pub enum RegisterCapability {}
+
+impl Request for RegisterCapability {
+    type Params = RegistrationParams;
+    type Result = ();
+    const METHOD: &'static str = "client/registerCapability";
+}
+
+/// The client/unregisterCapability request is sent from the server to the client to unregister a
+/// previously register capability.
+#[derive(Debug)]
+pub enum UnregisterCapability {}
+
+impl Request for UnregisterCapability {
+    type Params = UnregistrationParams;
+    type Result = ();
+    const METHOD: &'static str = "client/unregisterCapability";
 }
 
 /**


### PR DESCRIPTION
These are server->client requests (https://microsoft.github.io/language-server-protocol/specification#client_registerCapability), I must've made a mistake last time I implemented traits for messages.
Also added separating whitespace and reordered workspace macros in request.rs to mimic order given [here](https://microsoft.github.io/language-server-protocol/specification).