### PR TITLE
Fix invalid notification Params types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,6 +568,9 @@ pub struct InitializeParams {
     pub trace: TraceOption,
 }
 
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct InitializedParams { }
+
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TraceOption {
     #[serde(rename = "off")] Off,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -49,7 +49,7 @@ impl Notification for Cancel {
 pub enum Initialized {}
 
 impl Notification for Initialized {
-    type Params = ();
+    type Params = InitializedParams;
     const METHOD: &'static str = "initialized";
 }
 
@@ -96,7 +96,7 @@ impl Notification for LogMessage {
 pub enum TelemetryEvent {}
 
 impl Notification for TelemetryEvent {
-    type Params = ();
+    type Params = serde_json::Value;
     const METHOD: &'static str = "telemetry/event";
 }
 
@@ -142,7 +142,7 @@ impl Notification for DidChangeTextDocument {
 pub enum WillSave {}
 
 impl Notification for WillSave {
-    type Params = ();
+    type Params = WillSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/willSave";
 }
 
@@ -155,7 +155,7 @@ impl Notification for WillSave {
 pub enum WillSaveWaitUntil {}
 
 impl Notification for WillSaveWaitUntil {
-    type Params = ();
+    type Params = WillSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/willSaveWaitUntil";
 }
 


### PR DESCRIPTION
Fixes #46.

Since serde_json serializes `()` as `null`, we need to provide a structured value (here `pub struct InitializedParams { }`, matching LSP definition), so that we serde_json can parse `{}` as `<Initialized as Notification>::Params`, as expected.
Additionally this fixes some other Params types that had an wrong `()` Params type.