### PR TITLE
Remove mention of JSON that does not exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,7 +427,6 @@ impl WorkspaceEdit {
 }
 
 /// Text documents are identified using a URI. On the protocol level, URIs are passed as strings.
-/// The corresponding JSON structure looks like this:
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct TextDocumentIdentifier {
     // !!!!!! Note:


### PR DESCRIPTION
These comments have been copy-pasted from the spec so things are
sometimes wrong. The JSON in question don't add any information that
can't be inferred from the definition so it is removed.

Closes #61