### PR TITLE
Macro fixes

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -243,7 +243,7 @@ mod test {
     use std::mem;
     use super::*;
 
-    fn fake_call<N>(_params: N::Params)
+    fn fake_call<N>()
         where N: Notification,
               N::Params: serde::Serialize,
     { }
@@ -253,11 +253,7 @@ mod test {
             // check whethe the macro name matches the method
             assert_eq!(<lsp_notification!($name) as Notification>::METHOD, $name);
             // test whether type checking passes for each component
-            if false {
-                // don't want to actually implement/run this
-                let params: <lsp_notification!($name) as Notification>::Params = unsafe { mem::uninitialized() };
-                fake_call::<lsp_notification!($name)>(params);
-            }
+            fake_call::<lsp_notification!($name)>();
         }
     }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -240,7 +240,6 @@ impl Notification for PublishDiagnostics {
 
 #[cfg(test)]
 mod test {
-    use std::mem;
     use super::*;
 
     fn fake_call<N>()

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -25,7 +25,7 @@ macro_rules! lsp_notification {
     };
 
     ("telemetry/event") => {
-        $crate::notification::Event
+        $crate::notification::TelemetryEvent
     };
 
     ("textDocument/didOpen") => {
@@ -36,6 +36,9 @@ macro_rules! lsp_notification {
     };
     ("textDocument/willSave") => {
         $crate::notification::WillSaveTextDocument
+    };
+    ("textDocument/willSaveWaitUntil") => {
+        $crate::notification::WillSaveWaitUntil
     };
     ("textDocument/didSave") => {
         $crate::notification::DidSaveTextDocument
@@ -232,4 +235,45 @@ pub enum PublishDiagnostics {}
 impl Notification for PublishDiagnostics {
     type Params = PublishDiagnosticsParams;
     const METHOD: &'static str = "textDocument/publishDiagnostics";
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::mem;
+
+    fn fake_call<N: Notification>(_params: N::Params) { }
+
+    macro_rules! check_macro {
+        ($name:tt) => {
+            // check whethe the macro name matches the method
+            assert_eq!(<lsp_notification!($name) as Notification>::METHOD, $name);
+            // test whether type checking passes for each component
+            if false {
+                // don't want to actually implement/run this
+                let params: <lsp_notification!($name) as Notification>::Params = unsafe { mem::uninitialized() };
+                fake_call::<lsp_notification!($name)>(params);
+            }
+        }
+    }
+
+    #[test]
+    fn check_macro_definition() {
+        check_macro!("$/cancelRequest");
+        check_macro!("initialized");
+        check_macro!("exit");
+        check_macro!("window/showMessage");
+        check_macro!("window/logMessage");
+        check_macro!("telemetry/event");
+        check_macro!("textDocument/didOpen");
+        check_macro!("textDocument/didChange");
+        check_macro!("textDocument/willSave");
+        check_macro!("textDocument/willSaveWaitUntil");
+        check_macro!("textDocument/didSave");
+        check_macro!("textDocument/didClose");
+        check_macro!("textDocument/publishDiagnostics");
+        check_macro!("workspace/didChangeConfiguration");
+        check_macro!("workspace/didChangeWatchedFiles");
+    }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -240,10 +240,13 @@ impl Notification for PublishDiagnostics {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::mem;
+    use super::*;
 
-    fn fake_call<N: Notification>(_params: N::Params) { }
+    fn fake_call<N>(_params: N::Params)
+        where N: Notification,
+              N::Params: serde::Serialize,
+    { }
 
     macro_rules! check_macro {
         ($name:tt) => {
@@ -259,7 +262,7 @@ mod test {
     }
 
     #[test]
-    fn check_macro_definition() {
+    fn check_macro_definitions() {
         check_macro!("$/cancelRequest");
         check_macro!("initialized");
         check_macro!("exit");

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -167,9 +167,9 @@ impl Notification for DidChangeTextDocument {
 /// The document will save notification is sent from the client to the server before the document
 /// is actually saved.
 #[derive(Debug)]
-pub enum WillSave {}
+pub enum WillSaveTextDocument {}
 
-impl Notification for WillSave {
+impl Notification for WillSaveTextDocument {
     type Params = WillSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/willSave";
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -447,10 +447,14 @@ impl Request for Rename {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::mem;
+    use super::*;
 
-    fn fake_call<R: Request>(_params: R::Params) -> R::Result {
+    fn fake_call<R>(_params: R::Params) -> R::Result
+        where R: Request,
+              R::Params: serde::Serialize,
+              R::Result: serde::de::DeserializeOwned
+    {
         unimplemented!()
     }
 
@@ -468,7 +472,7 @@ mod test {
     }
 
     #[test]
-    fn check_macro_definition() {
+    fn check_macro_definitions() {
         check_macro!("initialize");
         check_macro!("shutdown");
         check_macro!("window/showMessageRequest");

--- a/src/request.rs
+++ b/src/request.rs
@@ -33,9 +33,6 @@ macro_rules! lsp_request {
         $crate::request::ExecuteCommand
     };
 
-    ("textDocument/willSaveWaitUntil") => {
-        $crate::request::WillSaveWaitUntil
-    };
     ("textDocument/completion") => {
         $crate::request::Completion
     };
@@ -75,7 +72,7 @@ macro_rules! lsp_request {
     ("documentLink/resolve") => {
         $crate::request::DocumentLinkResolve
     };
-    ("textDocument/applyEdit") => {
+    ("workspace/applyEdit") => {
         $crate::request::ApplyWorkspaceEdit
     };
     ("textDocument/rangeFormatting") => {
@@ -446,4 +443,56 @@ impl Request for Rename {
     type Params = RenameParams;
     type Result = Option<WorkspaceEdit>;
     const METHOD: &'static str = "textDocument/rename";
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::mem;
+
+    fn fake_call<R: Request>(_params: R::Params) -> R::Result {
+        unimplemented!()
+    }
+
+    macro_rules! check_macro {
+        ($name:tt) => {
+            // check whethe the macro name matches the method
+            assert_eq!(<lsp_request!($name) as Request>::METHOD, $name);
+            // test whether type checking passes for each component
+            if false {
+                // don't want to actually implement/run this
+                let params: <lsp_request!($name) as Request>::Params = unsafe { mem::uninitialized()};
+                let _res: <lsp_request!($name) as Request>::Result = fake_call::<lsp_request!($name)>(params);
+            }
+        }
+    }
+
+    #[test]
+    fn check_macro_definition() {
+        check_macro!("initialize");
+        check_macro!("shutdown");
+        check_macro!("window/showMessageRequest");
+        check_macro!("client/registerCapability");
+        check_macro!("client/unregisterCapability");
+        check_macro!("workspace/symbol");
+        check_macro!("workspace/executeCommand");
+        check_macro!("textDocument/completion");
+        check_macro!("completionItem/resolve");
+        check_macro!("textDocument/hover");
+        check_macro!("textDocument/signatureHelp");
+        check_macro!("textDocument/definition");
+        check_macro!("textDocument/references");
+        check_macro!("textDocument/documentHighlight");
+        check_macro!("textDocument/documentSymbol");
+        check_macro!("textDocument/codeAction");
+        check_macro!("textDocument/codeLens");
+        check_macro!("codeLens/resolve");
+        check_macro!("textDocument/documentLink");
+        check_macro!("documentLink/resolve");
+        check_macro!("workspace/applyEdit");
+        check_macro!("textDocument/rangeFormatting");
+        check_macro!("textDocument/onTypeFormatting");
+        check_macro!("textDocument/formatting");
+        check_macro!("textDocument/rename");
+    }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -450,12 +450,11 @@ mod test {
     use std::mem;
     use super::*;
 
-    fn fake_call<R>(_params: R::Params) -> R::Result
+    fn fake_call<R>()
         where R: Request,
               R::Params: serde::Serialize,
               R::Result: serde::de::DeserializeOwned
     {
-        unimplemented!()
     }
 
     macro_rules! check_macro {
@@ -463,11 +462,7 @@ mod test {
             // check whethe the macro name matches the method
             assert_eq!(<lsp_request!($name) as Request>::METHOD, $name);
             // test whether type checking passes for each component
-            if false {
-                // don't want to actually implement/run this
-                let params: <lsp_request!($name) as Request>::Params = unsafe { mem::uninitialized()};
-                let _res: <lsp_request!($name) as Request>::Result = fake_call::<lsp_request!($name)>(params);
-            }
+            fake_call::<lsp_request!($name)>();
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -61,7 +61,7 @@ macro_rules! lsp_request {
         $crate::request::DocumentSymbol
     };
     ("textDocument/codeAction") => {
-        $crate::request::CodeAction
+        $crate::request::CodeActionRequest
     };
     ("textDocument/codeLens") => {
         $crate::request::CodeLensRequest
@@ -70,13 +70,13 @@ macro_rules! lsp_request {
         $crate::request::CodeLensResolve
     };
     ("textDocument/documentLink") => {
-        $crate::request::DocumentLink
+        $crate::request::DocumentLinkRequest
     };
     ("documentLink/resolve") => {
         $crate::request::DocumentLinkResolve
     };
     ("textDocument/applyEdit") => {
-        $crate::request::ApplyEdit
+        $crate::request::ApplyWorkspaceEdit
     };
     ("textDocument/rangeFormatting") => {
         $crate::request::RangeFormatting

--- a/src/request.rs
+++ b/src/request.rs
@@ -55,7 +55,7 @@ macro_rules! lsp_request {
         $crate::request::DocumentHighlightRequest
     };
     ("textDocument/documentSymbol") => {
-        $crate::request::DocumentSymbol
+        $crate::request::DocumentSymbolRequest
     };
     ("textDocument/codeAction") => {
         $crate::request::CodeActionRequest
@@ -447,7 +447,6 @@ impl Request for Rename {
 
 #[cfg(test)]
 mod test {
-    use std::mem;
     use super::*;
 
     fn fake_call<R>()


### PR DESCRIPTION
I came across some cases where the `lsp_request!` and `lsp_notification!` macros returned missing types. I also added a couple of tests to help type-check these, and verify the macro names matched the method names.

**Note** that in addition to fixing the macros, I changed the `WillSave` enum to `WillSaveTextDocument` to be more consistent with the others. This has the potential to break crates depending on that enum, so if it's considered too late to change this, I can just fix the macro instead.