### PR TITLE
Reexport URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate serde_json;
 extern crate url;
 extern crate url_serde;
 
-use url::Url;
+pub use url::Url;
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
This makes using `lanugageserver_types` slightly more convenient. 