### PR TITLE
Skip serializing link support if it is None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,6 +1099,7 @@ pub struct GotoCapability {
     pub dynamic_registration: Option<bool>,
 
     /// The client supports additional metadata in the form of definition links.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_support: Option<bool>,
 }
 


### PR DESCRIPTION
Currently if this isn't specified (such as being left to `GotoCapability::default()`) then it will be serialized as `Null`. The Julia LSP will panic if it sees that field defined and not with a boolean value.  
This PR updates the field to be skipped when it is `None`, matching the specification.