### PR TITLE
deps: Update `bitflags` from 1.x to 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["language", "server", "lsp", "vscode", "lsif"]
 license = "MIT"
 
 [dependencies]
-bitflags = "1.0.1"
+bitflags = "2.6.0"
 serde = { version = "1.0.34", features = ["derive"] }
 serde_json = "1.0.50"
 serde_repr = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@ Based on: <https://microsoft.github.io/language-server-protocol/specification>
 */
 #![allow(non_upper_case_globals)]
 #![forbid(unsafe_code)]
-#[macro_use]
-extern crate bitflags;
 
 use std::{collections::HashMap, fmt::Debug};
 
@@ -2385,7 +2383,8 @@ pub struct RelativePattern {
 /// @since 3.17.0
 pub type Pattern = String;
 
-bitflags! {
+bitflags::bitflags! {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WatchKind: u8 {
     /// Interested in create events.
     const Create = 1;


### PR DESCRIPTION
This also removes the usage of `extern crate` and `#[macro_use]` which were no longer required with Rust 2018 edition and later.