### PR TITLE
Update CI: use current checkout, stop using actions-rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,13 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
-        override: true
 
     - name: Build
       run: cargo build


### PR DESCRIPTION
The actions from actions-rs haven't been maintained in a long time and the `dtolnay/rust-toolchain` is being actively maintained and widely used.