### PR TITLE
feat: derive Hash for all data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,12 @@ serde = { version = "1.0.34", features = ["derive"] }
 serde_json = "1.0.50"
 serde_repr = "0.1"
 fluent-uri = "0.1.4"
+ordermap = { version = "0.5.3", features = ["serde"], optional = true }
 
 [features]
 default = []
 # Enables proposed LSP extensions.
 # NOTE: No semver compatibility is guaranteed for types enabled by this feature.
 proposed = []
+
+hash = ["dep:ordermap"]

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -10,6 +10,7 @@ pub type CallHierarchyClientCapabilities = DynamicRegistrationClientCapabilities
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize, Copy)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -17,6 +18,7 @@ pub struct CallHierarchyOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Copy)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CallHierarchyServerCapability {
     Simple(bool),
     Options(CallHierarchyOptions),
@@ -36,6 +38,7 @@ impl From<bool> for CallHierarchyServerCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyPrepareParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -46,6 +49,7 @@ pub struct CallHierarchyPrepareParams {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyItem {
     /// The name of this item.
     pub name: String,
@@ -78,6 +82,7 @@ pub struct CallHierarchyItem {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyIncomingCallsParams {
     pub item: CallHierarchyItem,
 
@@ -91,6 +96,7 @@ pub struct CallHierarchyIncomingCallsParams {
 /// Represents an incoming call, e.g. a caller of a method or constructor.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyIncomingCall {
     /// The item that makes the call.
     pub from: CallHierarchyItem,
@@ -102,6 +108,7 @@ pub struct CallHierarchyIncomingCall {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyOutgoingCallsParams {
     pub item: CallHierarchyItem,
 
@@ -115,6 +122,7 @@ pub struct CallHierarchyOutgoingCallsParams {
 /// Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CallHierarchyOutgoingCall {
     /// The item that is called.
     pub to: CallHierarchyItem,

--- a/src/code_action.rs
+++ b/src/code_action.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeActionProviderCapability {
     Simple(bool),
     Options(CodeActionOptions),
@@ -28,6 +29,7 @@ impl From<bool> for CodeActionProviderCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionClientCapabilities {
     ///
     /// This capability supports dynamic registration.
@@ -84,6 +86,7 @@ pub struct CodeActionClientCapabilities {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionCapabilityResolveSupport {
     /// The properties that a client can resolve lazily.
     pub properties: Vec<String>,
@@ -91,6 +94,7 @@ pub struct CodeActionCapabilityResolveSupport {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionLiteralSupport {
     /// The code action kind is support with the following value set.
     pub code_action_kind: CodeActionKindLiteralSupport,
@@ -98,6 +102,7 @@ pub struct CodeActionLiteralSupport {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionKindLiteralSupport {
     /// The code action kind values the client supports. When this
     /// property exists the client also guarantees that it will
@@ -109,6 +114,7 @@ pub struct CodeActionKindLiteralSupport {
 /// Params for the CodeActionRequest
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionParams {
     /// The document in which the command was invoked.
     pub text_document: TextDocumentIdentifier,
@@ -131,6 +137,7 @@ pub type CodeActionResponse = Vec<CodeActionOrCommand>;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeActionOrCommand {
     Command(Command),
     CodeAction(CodeAction),
@@ -148,7 +155,8 @@ impl From<CodeAction> for CodeActionOrCommand {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionKind(Cow<'static, str>);
 
 impl CodeActionKind {
@@ -235,6 +243,7 @@ impl From<&'static str> for CodeActionKind {
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeAction {
     /// A short, human-readable, title for this code action.
     pub title: String,
@@ -296,6 +305,7 @@ pub struct CodeAction {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionDisabled {
     /// Human readable description of why the code action is currently disabled.
     ///
@@ -308,6 +318,7 @@ pub struct CodeActionDisabled {
 /// @since 3.17.0
 #[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionTriggerKind(i32);
 lsp_enum! {
 impl CodeActionTriggerKind {
@@ -326,6 +337,7 @@ impl CodeActionTriggerKind {
 /// a code action is run.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionContext {
     /// An array of diagnostics.
     pub diagnostics: Vec<Diagnostic>,
@@ -346,6 +358,7 @@ pub struct CodeActionContext {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeActionOptions {
     /// CodeActionKinds that this server may return.
     ///

--- a/src/code_lens.rs
+++ b/src/code_lens.rs
@@ -11,6 +11,7 @@ pub type CodeLensClientCapabilities = DynamicRegistrationClientCapabilities;
 /// Code Lens options.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Copy)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeLensOptions {
     /// Code lens has a resolve provider as well.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,6 +20,7 @@ pub struct CodeLensOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeLensParams {
     /// The document to request code lens for.
     pub text_document: TextDocumentIdentifier,
@@ -37,6 +39,7 @@ pub struct CodeLensParams {
 /// reasons the creation of a code lens and resolving should be done in two stages.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeLens {
     /// The range in which this code lens is valid. Should only span a single line.
     pub range: Range,
@@ -53,6 +56,7 @@ pub struct CodeLens {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CodeLensWorkspaceClientCapabilities {
     /// Whether the client implementation supports a refresh request sent from the
     /// server to the client.

--- a/src/color.rs
+++ b/src/color.rs
@@ -8,10 +8,12 @@ pub type DocumentColorClientCapabilities = DynamicRegistrationClientCapabilities
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ColorProviderOptions {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct StaticTextDocumentColorProviderOptions {
     /// A document selector to identify the scope of the registration. If set to null
     /// the document selector provided on the client side will be used.
@@ -23,6 +25,7 @@ pub struct StaticTextDocumentColorProviderOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ColorProviderCapability {
     Simple(bool),
     ColorProvider(ColorProviderOptions),
@@ -49,6 +52,7 @@ impl From<bool> for ColorProviderCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentColorParams {
     /// The text document
     pub text_document: TextDocumentIdentifier,
@@ -62,6 +66,7 @@ pub struct DocumentColorParams {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ColorInformation {
     /// The range in the document where this color appears.
     pub range: Range,
@@ -82,8 +87,19 @@ pub struct Color {
     pub alpha: f32,
 }
 
+#[cfg(feature = "hash")]
+impl std::hash::Hash for Color {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.red.to_bits().hash(state);
+        self.green.to_bits().hash(state);
+        self.blue.to_bits().hash(state);
+        self.alpha.to_bits().hash(state);
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ColorPresentationParams {
     /// The text document.
     pub text_document: TextDocumentIdentifier,
@@ -103,6 +119,7 @@ pub struct ColorPresentationParams {
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ColorPresentation {
     /// The label of this color presentation. It will be shown on the color
     /// picker header. By default this is also the text that is inserted when selecting

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 /// Defines how to interpret the insert text in a completion item
 #[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InsertTextFormat(i32);
 lsp_enum! {
 impl InsertTextFormat {
@@ -24,6 +25,7 @@ impl InsertTextFormat {
 /// The kind of a completion entry.
 #[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemKind(i32);
 lsp_enum! {
 impl CompletionItemKind {
@@ -57,6 +59,7 @@ impl CompletionItemKind {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemCapability {
     /// Client supports snippets as insert text.
     ///
@@ -128,6 +131,7 @@ pub struct CompletionItemCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemCapabilityResolveSupport {
     /// The properties that a client can resolve lazily.
     pub properties: Vec<String>,
@@ -135,6 +139,7 @@ pub struct CompletionItemCapabilityResolveSupport {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InsertTextModeSupport {
     pub value_set: Vec<InsertTextMode>,
 }
@@ -145,6 +150,7 @@ pub struct InsertTextModeSupport {
 /// @since 3.16.0
 #[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InsertTextMode(i32);
 lsp_enum! {
 impl InsertTextMode {
@@ -168,6 +174,7 @@ impl InsertTextMode {
 
 #[derive(Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemTag(i32);
 lsp_enum! {
 impl CompletionItemTag {
@@ -177,6 +184,7 @@ impl CompletionItemTag {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemKindCapability {
     /// The completion item kind values the client supports. When this
     /// property exists the client also guarantees that it will
@@ -192,6 +200,7 @@ pub struct CompletionItemKindCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionListCapability {
     /// The client supports the following itemDefaults on
     /// a completion list.
@@ -207,6 +216,7 @@ pub struct CompletionListCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionClientCapabilities {
     /// Whether completion supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -245,6 +255,7 @@ pub struct CompletionClientCapabilities {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InsertReplaceEdit {
     /// The string to be inserted.
     pub new_text: String,
@@ -258,6 +269,7 @@ pub struct InsertReplaceEdit {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CompletionTextEdit {
     Edit(TextEdit),
     InsertAndReplace(InsertReplaceEdit),
@@ -278,6 +290,7 @@ impl From<InsertReplaceEdit> for CompletionTextEdit {
 /// Completion options.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionOptions {
     /// The server provides support to resolve additional information for a completion item.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -321,6 +334,7 @@ pub struct CompletionOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionOptionsCompletionItem {
     /// The server has support for completion item label
     /// details (see also `CompletionItemLabelDetails`) when receiving
@@ -332,6 +346,7 @@ pub struct CompletionOptionsCompletionItem {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -342,6 +357,7 @@ pub struct CompletionRegistrationOptions {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CompletionResponse {
     Array(Vec<CompletionItem>),
     List(CompletionList),
@@ -361,6 +377,7 @@ impl From<CompletionList> for CompletionResponse {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionParams {
     // This field was "mixed-in" from TextDocumentPositionParams
     #[serde(flatten)]
@@ -379,6 +396,7 @@ pub struct CompletionParams {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionContext {
     /// How the completion was triggered.
     pub trigger_kind: CompletionTriggerKind,
@@ -392,6 +410,7 @@ pub struct CompletionContext {
 /// How a completion was triggered.
 #[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionTriggerKind(i32);
 lsp_enum! {
 impl CompletionTriggerKind {
@@ -405,6 +424,7 @@ impl CompletionTriggerKind {
 /// in the editor.
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionList {
     /// This list it not complete. Further typing should result in recomputing
     /// this list.
@@ -416,6 +436,7 @@ pub struct CompletionList {
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItem {
     /// The label of this completion item. By default
     /// also the text that is inserted when selecting
@@ -557,6 +578,7 @@ impl CompletionItem {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CompletionItemLabelDetails {
     /// An optional string which is rendered less prominently directly after
     /// {@link CompletionItemLabel.label label}, without any spacing. Should be

--- a/src/document_diagnostic.rs
+++ b/src/document_diagnostic.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Diagnostic, PartialResultParams, StaticRegistrationOptions, TextDocumentIdentifier,
-    TextDocumentRegistrationOptions, Uri, WorkDoneProgressOptions, WorkDoneProgressParams,
+    Diagnostic, Map, PartialResultParams, StaticRegistrationOptions, TextDocumentIdentifier, TextDocumentRegistrationOptions, Uri, WorkDoneProgressOptions, WorkDoneProgressParams
 };
 
 /// Client capabilities specific to diagnostic pull requests.
@@ -12,6 +10,7 @@ use crate::{
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DiagnosticClientCapabilities {
     /// Whether implementation supports dynamic registration.
     ///
@@ -30,6 +29,7 @@ pub struct DiagnosticClientCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DiagnosticOptions {
     /// An optional identifier under which the diagnostics are
     /// managed by the client.
@@ -53,6 +53,7 @@ pub struct DiagnosticOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DiagnosticRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -66,6 +67,7 @@ pub struct DiagnosticRegistrationOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DiagnosticServerCapabilities {
     Options(DiagnosticOptions),
     RegistrationOptions(DiagnosticRegistrationOptions),
@@ -76,6 +78,7 @@ pub enum DiagnosticServerCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentDiagnosticParams {
     /// The text document.
     pub text_document: TextDocumentIdentifier,
@@ -98,6 +101,7 @@ pub struct DocumentDiagnosticParams {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FullDocumentDiagnosticReport {
     /// An optional result ID. If provided it will be sent on the next diagnostic request for the
     /// same document.
@@ -115,6 +119,7 @@ pub struct FullDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct UnchangedDocumentDiagnosticReport {
     /// A result ID which will be sent on the next diagnostic request for the same document.
     pub result_id: String,
@@ -125,6 +130,7 @@ pub struct UnchangedDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentDiagnosticReportKind {
     /// A diagnostic report with a full set of problems.
     Full(FullDocumentDiagnosticReport),
@@ -149,6 +155,7 @@ impl From<UnchangedDocumentDiagnosticReport> for DocumentDiagnosticReportKind {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RelatedFullDocumentDiagnosticReport {
     /// Diagnostics of related documents.
     ///
@@ -159,7 +166,7 @@ pub struct RelatedFullDocumentDiagnosticReport {
     /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<Map<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
     #[serde(flatten)]
     pub full_document_diagnostic_report: FullDocumentDiagnosticReport,
@@ -170,6 +177,7 @@ pub struct RelatedFullDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RelatedUnchangedDocumentDiagnosticReport {
     /// Diagnostics of related documents.
     ///
@@ -180,7 +188,7 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
     /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<Map<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
     #[serde(flatten)]
     pub unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport,
@@ -195,6 +203,7 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentDiagnosticReport {
     /// A diagnostic report with a full set of problems.
     Full(RelatedFullDocumentDiagnosticReport),
@@ -219,15 +228,17 @@ impl From<RelatedUnchangedDocumentDiagnosticReport> for DocumentDiagnosticReport
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentDiagnosticReportPartialResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<Map<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentDiagnosticReportResult {
     Report(DocumentDiagnosticReport),
     Partial(DocumentDiagnosticReportPartialResult),
@@ -252,6 +263,7 @@ impl From<DocumentDiagnosticReportPartialResult> for DocumentDiagnosticReportRes
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DiagnosticServerCancellationData {
     pub retrigger_request: bool,
 }

--- a/src/document_highlight.rs
+++ b/src/document_highlight.rs
@@ -9,6 +9,7 @@ pub type DocumentHighlightClientCapabilities = DynamicRegistrationClientCapabili
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentHighlightParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -24,6 +25,7 @@ pub struct DocumentHighlightParams {
 /// special attention. Usually a document highlight is visualized by changing
 /// the background color of its range.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentHighlight {
     /// The range this highlight applies to.
     pub range: Range,
@@ -36,6 +38,7 @@ pub struct DocumentHighlight {
 /// A document highlight kind.
 #[derive(Eq, PartialEq, Copy, Clone, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentHighlightKind(i32);
 lsp_enum! {
 impl DocumentHighlightKind {

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentLinkClientCapabilities {
     /// Whether document link supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,6 +20,7 @@ pub struct DocumentLinkClientCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentLinkOptions {
     /// Document links have a resolve provider as well.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,6 +32,7 @@ pub struct DocumentLinkOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentLinkParams {
     /// The document to provide document links for.
     pub text_document: TextDocumentIdentifier,
@@ -44,6 +47,7 @@ pub struct DocumentLinkParams {
 /// A document link is a range in a text document that links to an internal or external resource, like another
 /// text document or a web site.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentLink {
     /// The range this link applies to.
     pub range: Range,

--- a/src/document_symbols.rs
+++ b/src/document_symbols.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentSymbolClientCapabilities {
     /// This capability supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,6 +38,7 @@ pub struct DocumentSymbolClientCapabilities {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentSymbolResponse {
     Flat(Vec<SymbolInformation>),
     Nested(Vec<DocumentSymbol>),
@@ -56,6 +58,7 @@ impl From<Vec<DocumentSymbol>> for DocumentSymbolResponse {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentSymbolParams {
     /// The text document.
     pub text_document: TextDocumentIdentifier,
@@ -73,6 +76,7 @@ pub struct DocumentSymbolParams {
 /// e.g. the range of an identifier.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentSymbol {
     /// The name of this symbol.
     pub name: String,
@@ -107,6 +111,7 @@ pub struct DocumentSymbol {
 /// interfaces etc.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SymbolInformation {
     /// The name of this symbol.
     pub name: String,

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFileOperationsClientCapabilities {
     /// Whether the client supports dynamic registration for file
     /// requests/notifications.
@@ -35,6 +36,7 @@ pub struct WorkspaceFileOperationsClientCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFileOperationsServerCapabilities {
     /// The server is interested in receiving didCreateFiles
     /// notifications.
@@ -70,6 +72,7 @@ pub struct WorkspaceFileOperationsServerCapabilities {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileOperationRegistrationOptions {
     /// The actual filters.
     pub filters: Vec<FileOperationFilter>,
@@ -81,6 +84,7 @@ pub struct FileOperationRegistrationOptions {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileOperationFilter {
     /// A Uri like `file` or `untitled`.
     pub scheme: Option<String>,
@@ -95,6 +99,7 @@ pub struct FileOperationFilter {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum FileOperationPatternKind {
     /// The pattern matches a file only.
     File,
@@ -109,6 +114,7 @@ pub enum FileOperationPatternKind {
 ///
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileOperationPatternOptions {
     /// The pattern should be matched ignoring casing.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,6 +127,7 @@ pub struct FileOperationPatternOptions {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileOperationPattern {
     /// The glob pattern to match. Glob patterns can have the following syntax:
     /// - `*` to match one or more characters in a path segment
@@ -152,6 +159,7 @@ pub struct FileOperationPattern {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct CreateFilesParams {
     /// An array of all files/folders created in this operation.
     pub files: Vec<FileCreate>,
@@ -161,6 +169,7 @@ pub struct CreateFilesParams {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileCreate {
     /// A file:// URI for the location of the file/folder being created.
     pub uri: String,
@@ -172,6 +181,7 @@ pub struct FileCreate {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RenameFilesParams {
     /// An array of all files/folders renamed in this operation. When a folder
     /// is renamed, only the folder will be included, and not its children.
@@ -183,6 +193,7 @@ pub struct RenameFilesParams {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileRename {
     /// A file:// URI for the original location of the file/folder being renamed.
     pub old_uri: String,
@@ -197,6 +208,7 @@ pub struct FileRename {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DeleteFilesParams {
     /// An array of all files/folders deleted in this operation.
     pub files: Vec<FileDelete>,
@@ -207,6 +219,7 @@ pub struct DeleteFilesParams {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FileDelete {
     /// A file:// URI for the location of the file/folder being deleted.
     pub uri: String,

--- a/src/folding_range.rs
+++ b/src/folding_range.rs
@@ -5,6 +5,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingRangeParams {
     /// The text document.
     pub text_document: TextDocumentIdentifier,
@@ -18,6 +19,7 @@ pub struct FoldingRangeParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum FoldingRangeProviderCapability {
     Simple(bool),
     FoldingProvider(FoldingProviderOptions),
@@ -43,10 +45,12 @@ impl From<bool> for FoldingRangeProviderCapability {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingProviderOptions {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingRangeKindCapability {
     /// The folding range kind values the client supports. When this
     /// property exists the client also guarantees that it will
@@ -58,6 +62,7 @@ pub struct FoldingRangeKindCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingRangeCapability {
     /// If set, the client signals that it supports setting collapsedText on
     /// folding ranges to display custom labels instead of the default text.
@@ -69,6 +74,7 @@ pub struct FoldingRangeCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingRangeClientCapabilities {
     /// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
     /// the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
@@ -102,6 +108,7 @@ pub struct FoldingRangeClientCapabilities {
 /// Enum of known range kinds
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum FoldingRangeKind {
     /// Folding range for a comment
     Comment,
@@ -114,6 +121,7 @@ pub enum FoldingRangeKind {
 /// Represents a folding range.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FoldingRange {
     /// The zero-based line number from where the folded range starts.
     pub start_line: u32,

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,11 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    DocumentSelector, DynamicRegistrationClientCapabilities, Range, TextDocumentIdentifier,
+    DocumentSelector, DynamicRegistrationClientCapabilities, Map, Range, TextDocumentIdentifier,
     TextDocumentPositionParams, WorkDoneProgressParams,
 };
-
-use std::collections::HashMap;
 
 pub type DocumentFormattingClientCapabilities = DynamicRegistrationClientCapabilities;
 pub type DocumentRangeFormattingClientCapabilities = DynamicRegistrationClientCapabilities;
@@ -14,6 +12,7 @@ pub type DocumentOnTypeFormattingClientCapabilities = DynamicRegistrationClientC
 /// Format document on type options
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentOnTypeFormattingOptions {
     /// A character on which formatting should be triggered, like `}`.
     pub first_trigger_character: String,
@@ -25,6 +24,7 @@ pub struct DocumentOnTypeFormattingOptions {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentFormattingParams {
     /// The document to format.
     pub text_document: TextDocumentIdentifier,
@@ -39,6 +39,7 @@ pub struct DocumentFormattingParams {
 /// Value-object describing what options formatting should use.
 #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct FormattingOptions {
     /// Size of a tab in spaces.
     pub tab_size: u32,
@@ -48,7 +49,7 @@ pub struct FormattingOptions {
 
     /// Signature for further properties.
     #[serde(flatten)]
-    pub properties: HashMap<String, FormattingProperty>,
+    pub properties: Map<String, FormattingProperty>,
 
     /// Trim trailing whitespace on a line.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +66,7 @@ pub struct FormattingOptions {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum FormattingProperty {
     Bool(bool),
     Number(i32),
@@ -73,6 +75,7 @@ pub enum FormattingProperty {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentRangeFormattingParams {
     /// The document to format.
     pub text_document: TextDocumentIdentifier,
@@ -89,6 +92,7 @@ pub struct DocumentRangeFormattingParams {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentOnTypeFormattingParams {
     /// Text Document and Position fields.
     #[serde(flatten)]
@@ -104,6 +108,7 @@ pub struct DocumentOnTypeFormattingParams {
 /// Extends TextDocumentRegistrationOptions
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DocumentOnTypeFormattingRegistrationOptions {
     /// A document selector to identify the scope of the registration. If set to null
     /// the document selector provided on the client side will be used.
@@ -128,7 +133,7 @@ mod tests {
             &FormattingOptions {
                 tab_size: 123,
                 insert_spaces: true,
-                properties: HashMap::new(),
+                properties: Map::new(),
                 trim_trailing_whitespace: None,
                 insert_final_newline: None,
                 trim_final_newlines: None,

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -7,6 +7,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct HoverClientCapabilities {
     /// Whether completion supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,6 +22,7 @@ pub struct HoverClientCapabilities {
 /// Hover options.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct HoverOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -28,6 +30,7 @@ pub struct HoverOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct HoverRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -38,6 +41,7 @@ pub struct HoverRegistrationOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum HoverProviderCapability {
     Simple(bool),
     Options(HoverOptions),
@@ -57,6 +61,7 @@ impl From<bool> for HoverProviderCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct HoverParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -67,6 +72,7 @@ pub struct HoverParams {
 
 /// The result of a hover request.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Hover {
     /// The hover's content
     pub contents: HoverContents,
@@ -79,6 +85,7 @@ pub struct Hover {
 /// Hover contents could be single entry or multiple entries.
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum HoverContents {
     Scalar(MarkedString),
     Array(Vec<MarkedString>),

--- a/src/inlay_hint.rs
+++ b/src/inlay_hint.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintServerCapabilities {
     Options(InlayHintOptions),
     RegistrationOptions(InlayHintRegistrationOptions),
@@ -18,6 +19,7 @@ pub enum InlayHintServerCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintClientCapabilities {
     /// Whether inlay hints support dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -34,6 +36,7 @@ pub struct InlayHintClientCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -49,6 +52,7 @@ pub struct InlayHintOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintRegistrationOptions {
     #[serde(flatten)]
     pub inlay_hint_options: InlayHintOptions,
@@ -65,6 +69,7 @@ pub struct InlayHintRegistrationOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -81,6 +86,7 @@ pub struct InlayHintParams {
 /// @since 3.17.0
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHint {
     /// The position of this hint.
     pub position: Position,
@@ -138,6 +144,7 @@ pub struct InlayHint {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintLabel {
     String(String),
     LabelParts(Vec<InlayHintLabelPart>),
@@ -159,6 +166,7 @@ impl From<Vec<InlayHintLabelPart>> for InlayHintLabel {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintTooltip {
     String(String),
     MarkupContent(MarkupContent),
@@ -182,6 +190,7 @@ impl From<MarkupContent> for InlayHintTooltip {
 /// of inlay hints.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintLabelPart {
     /// The value of this label part.
     pub value: String,
@@ -216,6 +225,7 @@ pub struct InlayHintLabelPart {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintLabelPartTooltip {
     String(String),
     MarkupContent(MarkupContent),
@@ -240,6 +250,7 @@ impl From<MarkupContent> for InlayHintLabelPartTooltip {
 /// @since 3.17.0
 #[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintKind(i32);
 lsp_enum! {
 impl InlayHintKind {
@@ -256,6 +267,7 @@ impl InlayHintKind {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintResolveClientCapabilities {
     /// The properties that a client can resolve lazily.
     pub properties: Vec<String>,
@@ -266,6 +278,7 @@ pub struct InlayHintResolveClientCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlayHintWorkspaceClientCapabilities {
     /// Whether the client implementation supports a refresh request sent from
     /// the server to the client.

--- a/src/inline_completion.rs
+++ b/src/inline_completion.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionClientCapabilities {
     /// Whether implementation supports dynamic registration for inline completion providers.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,6 +20,7 @@ pub struct InlineCompletionClientCapabilities {
 ///
 /// @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -28,6 +30,7 @@ pub struct InlineCompletionOptions {
 ///
 // @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionRegistrationOptions {
     #[serde(flatten)]
     pub inline_completion_options: InlineCompletionOptions,
@@ -44,6 +47,7 @@ pub struct InlineCompletionRegistrationOptions {
 /// @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -59,6 +63,7 @@ pub struct InlineCompletionParams {
 ///
 /// @since 3.18.0
 #[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionTriggerKind(i32);
 lsp_enum! {
 impl InlineCompletionTriggerKind {
@@ -76,6 +81,7 @@ impl InlineCompletionTriggerKind {
 ///
 /// @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectedCompletionInfo {
     /// The range that will be replaced if this completion item is accepted.
     pub range: Range,
@@ -90,6 +96,7 @@ pub struct SelectedCompletionInfo {
 /// @since 3.18.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionContext {
     /// Describes how the inline completion was triggered.
     pub trigger_kind: InlineCompletionTriggerKind,
@@ -112,6 +119,7 @@ pub struct InlineCompletionContext {
 /// InlineCompletion response can be multiple completion items, or a list of completion items
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineCompletionResponse {
     Array(Vec<InlineCompletionItem>),
     List(InlineCompletionList),
@@ -121,6 +129,7 @@ pub enum InlineCompletionResponse {
 ///
 /// @since 3.18.0
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionList {
     /// The inline completion items
     pub items: Vec<InlineCompletionItem>,
@@ -132,6 +141,7 @@ pub struct InlineCompletionList {
 /// @since 3.18.0
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineCompletionItem {
     /// The text to replace the range with. Must be set.
     /// Is used both for the preview and the accept operation.

--- a/src/inline_value.rs
+++ b/src/inline_value.rs
@@ -9,6 +9,7 @@ pub type InlineValueClientCapabilities = DynamicRegistrationClientCapabilities;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineValueServerCapabilities {
     Options(InlineValueOptions),
     RegistrationOptions(InlineValueRegistrationOptions),
@@ -18,6 +19,7 @@ pub enum InlineValueServerCapabilities {
 ///
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -27,6 +29,7 @@ pub struct InlineValueOptions {
 ///
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueRegistrationOptions {
     #[serde(flatten)]
     pub inline_value_options: InlineValueOptions,
@@ -43,6 +46,7 @@ pub struct InlineValueRegistrationOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -61,6 +65,7 @@ pub struct InlineValueParams {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueContext {
     /// The stack frame (as a DAP Id) where the execution has stopped.
     pub frame_id: i32,
@@ -75,6 +80,7 @@ pub struct InlineValueContext {
 ///
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueText {
     /// The document range for which the inline value applies.
     pub range: Range,
@@ -93,6 +99,7 @@ pub struct InlineValueText {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueVariableLookup {
     /// The document range for which the inline value applies.
     /// The range is used to extract the variable name from the underlying
@@ -117,6 +124,7 @@ pub struct InlineValueVariableLookup {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueEvaluatableExpression {
     /// The document range for which the inline value applies.
     /// The range is used to extract the evaluatable expression from the
@@ -137,6 +145,7 @@ pub struct InlineValueEvaluatableExpression {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineValue {
     Text(InlineValueText),
     VariableLookup(InlineValueVariableLookup),
@@ -169,6 +178,7 @@ impl From<InlineValueEvaluatableExpression> for InlineValue {
 ///
 /// @since 3.17.0
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct InlineValueWorkspaceClientCapabilities {
     /// Whether the client implementation supports a refresh request sent from
     /// the server to the client.

--- a/src/linked_editing.rs
+++ b/src/linked_editing.rs
@@ -10,6 +10,7 @@ pub type LinkedEditingRangeClientCapabilities = DynamicRegistrationClientCapabil
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LinkedEditingRangeOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -17,6 +18,7 @@ pub struct LinkedEditingRangeOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LinkedEditingRangeRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -30,6 +32,7 @@ pub struct LinkedEditingRangeRegistrationOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum LinkedEditingRangeServerCapabilities {
     Simple(bool),
     Options(LinkedEditingRangeOptions),
@@ -38,6 +41,7 @@ pub enum LinkedEditingRangeServerCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LinkedEditingRangeParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -48,6 +52,7 @@ pub struct LinkedEditingRangeParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LinkedEditingRanges {
     /// A list of ranges that can be renamed together. The ranges must have
     /// identical length and contain identical text content. The ranges cannot overlap.

--- a/src/lsif.rs
+++ b/src/lsif.rs
@@ -11,6 +11,7 @@ pub type Id = crate::NumberOrString;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum LocationOrRangeId {
     Location(crate::Location),
     RangeId(Id),
@@ -18,6 +19,7 @@ pub enum LocationOrRangeId {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Entry {
     pub id: Id,
     #[serde(flatten)]
@@ -27,12 +29,14 @@ pub struct Entry {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Element {
     Vertex(Vertex),
     Edge(Edge),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ToolInfo {
     pub name: String,
     #[serde(default = "Default::default")]
@@ -43,6 +47,7 @@ pub struct ToolInfo {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Encoding {
     /// Currently only 'utf-16' is supported due to the limitations in LSP.
     #[serde(rename = "utf-16")]
@@ -50,6 +55,7 @@ pub enum Encoding {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RangeBasedDocumentSymbol {
     pub id: Id,
     #[serde(default = "Default::default")]
@@ -60,6 +66,7 @@ pub struct RangeBasedDocumentSymbol {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentSymbolOrRangeBasedVec {
     DocumentSymbol(Vec<crate::DocumentSymbol>),
     RangeBased(Vec<RangeBasedDocumentSymbol>),
@@ -67,6 +74,7 @@ pub enum DocumentSymbolOrRangeBasedVec {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DefinitionTag {
     /// The text covered by the range     
     text: String,
@@ -86,6 +94,7 @@ pub struct DefinitionTag {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DeclarationTag {
     /// The text covered by the range     
     text: String,
@@ -104,12 +113,14 @@ pub struct DeclarationTag {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ReferenceTag {
     text: String,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct UnknownTag {
     text: String,
 }
@@ -117,6 +128,7 @@ pub struct UnknownTag {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum RangeTag {
     Definition(DefinitionTag),
     Declaration(DeclarationTag),
@@ -127,6 +139,7 @@ pub enum RangeTag {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "label")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Vertex {
     MetaData(MetaData),
     /// <https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md#the-project-vertex>
@@ -171,6 +184,7 @@ pub enum Vertex {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum EventKind {
     Begin,
     End,
@@ -178,12 +192,14 @@ pub enum EventKind {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum EventScope {
     Document,
     Project,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Event {
     pub kind: EventKind,
     pub scope: EventScope,
@@ -193,6 +209,7 @@ pub struct Event {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "label")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Edge {
     Contains(EdgeDataMultiIn),
     Moniker(EdgeData),
@@ -226,6 +243,7 @@ pub enum Edge {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct EdgeData {
     pub in_v: Id,
     pub out_v: Id,
@@ -233,6 +251,7 @@ pub struct EdgeData {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct EdgeDataMultiIn {
     pub in_vs: Vec<Id>,
     pub out_v: Id,
@@ -240,6 +259,7 @@ pub struct EdgeDataMultiIn {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DefinitionResultType {
     Scalar(LocationOrRangeId),
     Array(LocationOrRangeId),
@@ -247,6 +267,7 @@ pub enum DefinitionResultType {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ItemKind {
     Declarations,
     Definitions,
@@ -257,6 +278,7 @@ pub enum ItemKind {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Item {
     pub document: Id,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -267,6 +289,7 @@ pub struct Item {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Document {
     pub uri: Uri,
     pub language_id: String,
@@ -275,6 +298,7 @@ pub struct Document {
 /// <https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md#result-set>
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ResultSet {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
@@ -283,6 +307,7 @@ pub struct ResultSet {
 /// <https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md#the-project-vertex>
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<Uri>,
@@ -293,6 +318,7 @@ pub struct Project {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MetaData {
     /// The version of the LSIF format using semver notation. See <https://semver.org/>. Please note
     /// the version numbers starting with 0 don't adhere to semver and adopters have to assume
@@ -313,6 +339,7 @@ pub struct MetaData {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Repository {
     pub r#type: String,
     pub url: String,
@@ -322,6 +349,7 @@ pub struct Repository {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct PackageInformation {
     pub name: String,
     pub manager: String,

--- a/src/moniker.rs
+++ b/src/moniker.rs
@@ -9,12 +9,14 @@ pub type MonikerClientCapabilities = DynamicRegistrationClientCapabilities;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum MonikerServerCapabilities {
     Options(MonikerOptions),
     RegistrationOptions(MonikerRegistrationOptions),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MonikerOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -22,6 +24,7 @@ pub struct MonikerOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MonikerRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -33,6 +36,7 @@ pub struct MonikerRegistrationOptions {
 /// Moniker uniqueness level to define scope of the moniker.
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum UniquenessLevel {
     /// The moniker is only unique inside a document
     Document,
@@ -49,6 +53,7 @@ pub enum UniquenessLevel {
 /// The moniker kind.
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum MonikerKind {
     /// The moniker represent a symbol that is imported into a project
     Import,
@@ -61,6 +66,7 @@ pub enum MonikerKind {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MonikerParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -75,6 +81,7 @@ pub struct MonikerParams {
 /// Moniker definition to match LSIF 0.5 moniker definition.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct Moniker {
     /// The scheme of the moniker. For example tsc or .Net
     pub scheme: String,

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -10,6 +10,7 @@ pub use notification_params::*;
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookDocument {
     /// The notebook document's URI.
     pub uri: Uri,
@@ -35,6 +36,7 @@ pub struct NotebookDocument {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookCell {
     /// The cell's kind
     pub kind: NotebookCellKind,
@@ -51,6 +53,7 @@ pub struct NotebookCell {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ExecutionSummary {
     /// A strict monotonically increasing value
     /// indicating the execution order of a cell
@@ -64,6 +67,7 @@ pub struct ExecutionSummary {
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum NotebookCellKind {
     /// A markup-cell is formatted source that is used for display.
     Markup = 1,
@@ -76,6 +80,7 @@ pub enum NotebookCellKind {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookDocumentClientCapabilities {
     /// Capabilities specific to notebook document synchronization
     ///
@@ -88,6 +93,7 @@ pub struct NotebookDocumentClientCapabilities {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookDocumentSyncClientCapabilities {
     /// Whether implementation supports dynamic registration. If this is
     /// set to `true` the client supports the new
@@ -116,6 +122,7 @@ pub struct NotebookDocumentSyncClientCapabilities {
 ///  @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookDocumentSyncOptions {
     /// The notebooks to be synced
     pub notebook_selector: Vec<NotebookSelector>,
@@ -130,6 +137,7 @@ pub struct NotebookDocumentSyncOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookDocumentSyncRegistrationOptions {
     /// The notebooks to be synced
     pub notebook_selector: Vec<NotebookSelector>,
@@ -149,6 +157,7 @@ pub struct NotebookDocumentSyncRegistrationOptions {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookCellTextDocumentFilter {
     /// A filter that matches against the notebook
     /// containing the notebook cell. If a string
@@ -165,6 +174,7 @@ pub struct NotebookCellTextDocumentFilter {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum NotebookSelector {
     ByNotebook {
         /// The notebook to be synced. If a string
@@ -188,12 +198,14 @@ pub enum NotebookSelector {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct NotebookCellSelector {
     pub language: String,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Notebook {
     String(String),
     NotebookDocumentFilter(NotebookDocumentFilter),
@@ -205,6 +217,7 @@ pub enum Notebook {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum NotebookDocumentFilter {
     ByType {
         /// The type of the enclosing notebook.
@@ -253,6 +266,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct DidOpenNotebookDocumentParams {
         /// The notebook document that got opened.
         pub notebook_document: NotebookDocument,
@@ -266,6 +280,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct DidChangeNotebookDocumentParams {
         /// The notebook document that did change. The version number points
         /// to the version after all provided changes have been applied.
@@ -290,6 +305,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct VersionedNotebookDocumentIdentifier {
         /// The version number of this notebook document.
         pub version: i32,
@@ -302,6 +318,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookDocumentChangeEvent {
         /// The changed meta data if any.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -314,6 +331,7 @@ mod notification_params {
 
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookDocumentCellChange {
         /// Changes to the cell structure to add or
         /// remove cells.
@@ -332,6 +350,7 @@ mod notification_params {
 
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookDocumentChangeTextContent {
         pub document: VersionedTextDocumentIdentifier,
         pub changes: Vec<TextDocumentContentChangeEvent>,
@@ -339,6 +358,7 @@ mod notification_params {
 
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookDocumentCellChangeStructure {
         /// The change to the cell array.
         pub array: NotebookCellArrayChange,
@@ -356,6 +376,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookCellArrayChange {
         /// The start offset of the cell that changed.
         pub start: u32,
@@ -373,6 +394,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct DidSaveNotebookDocumentParams {
         /// The notebook document that got saved.
         pub notebook_document: NotebookDocumentIdentifier,
@@ -383,6 +405,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct NotebookDocumentIdentifier {
         /// The notebook document's URI.
         pub uri: Uri,
@@ -393,6 +416,7 @@ mod notification_params {
     /// @since 3.17.0
     #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "hash", derive(Hash))]
     pub struct DidCloseNotebookDocumentParams {
         /// The notebook document that got closed.
         pub notebook_document: NotebookDocumentIdentifier,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -101,6 +101,7 @@ macro_rules! lsp_notification {
 /// It can not be left open / hanging. This is in line with the JSON RPC protocol that requires
 /// that every request sends a response back. In addition it allows for returning partial results on cancel.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Cancel {}
 
 impl Notification for Cancel {
@@ -111,6 +112,7 @@ impl Notification for Cancel {
 /// A notification that should be used by the client to modify the trace
 /// setting of the server.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SetTrace {}
 
 impl Notification for SetTrace {
@@ -124,6 +126,7 @@ impl Notification for SetTrace {
 /// `LogTrace` should be used for systematic trace reporting. For single debugging messages,
 /// the server should send `LogMessage` notifications.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum LogTrace {}
 
 impl Notification for LogTrace {
@@ -136,6 +139,7 @@ impl Notification for LogTrace {
 /// notification to the server. The server can use the initialized notification for example to
 /// dynamically register capabilities.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Initialized {}
 
 impl Notification for Initialized {
@@ -147,6 +151,7 @@ impl Notification for Initialized {
 /// The server should exit with success code 0 if the shutdown request has been received before;
 /// otherwise with error code 1.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Exit {}
 
 impl Notification for Exit {
@@ -157,6 +162,7 @@ impl Notification for Exit {
 /// The show message notification is sent from a server to a client to ask the client to display a particular message
 /// in the user interface.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ShowMessage {}
 
 impl Notification for ShowMessage {
@@ -166,6 +172,7 @@ impl Notification for ShowMessage {
 
 /// The log message notification is sent from the server to the client to ask the client to log a particular message.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum LogMessage {}
 
 impl Notification for LogMessage {
@@ -177,6 +184,7 @@ impl Notification for LogMessage {
 /// The protocol doesn't specify the payload since no interpretation of the data happens in the protocol. Most clients even don't handle
 /// the event directly but forward them to the extensions owning the corresponding server issuing the event.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum TelemetryEvent {}
 
 impl Notification for TelemetryEvent {
@@ -186,6 +194,7 @@ impl Notification for TelemetryEvent {
 
 /// A notification sent from the client to the server to signal the change of configuration settings.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidChangeConfiguration {}
 
 impl Notification for DidChangeConfiguration {
@@ -197,6 +206,7 @@ impl Notification for DidChangeConfiguration {
 /// The document's truth is now managed by the client and the server must not try to read the document's truth
 /// using the document's uri.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidOpenTextDocument {}
 
 impl Notification for DidOpenTextDocument {
@@ -207,6 +217,7 @@ impl Notification for DidOpenTextDocument {
 /// The document change notification is sent from the client to the server to signal changes to a text document.
 /// In 2.0 the shape of the params has changed to include proper version numbers and language ids.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidChangeTextDocument {}
 
 impl Notification for DidChangeTextDocument {
@@ -217,6 +228,7 @@ impl Notification for DidChangeTextDocument {
 /// The document will save notification is sent from the client to the server before the document
 /// is actually saved.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WillSaveTextDocument {}
 
 impl Notification for WillSaveTextDocument {
@@ -228,6 +240,7 @@ impl Notification for WillSaveTextDocument {
 /// The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri
 /// the truth now exists on disk).
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidCloseTextDocument {}
 
 impl Notification for DidCloseTextDocument {
@@ -237,6 +250,7 @@ impl Notification for DidCloseTextDocument {
 
 /// The document save notification is sent from the client to the server when the document was saved in the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidSaveTextDocument {}
 
 impl Notification for DidSaveTextDocument {
@@ -245,6 +259,7 @@ impl Notification for DidSaveTextDocument {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidOpenNotebookDocument {}
 impl Notification for DidOpenNotebookDocument {
     type Params = DidOpenNotebookDocumentParams;
@@ -252,6 +267,7 @@ impl Notification for DidOpenNotebookDocument {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidChangeNotebookDocument {}
 impl Notification for DidChangeNotebookDocument {
     type Params = DidChangeNotebookDocumentParams;
@@ -259,6 +275,7 @@ impl Notification for DidChangeNotebookDocument {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidSaveNotebookDocument {}
 impl Notification for DidSaveNotebookDocument {
     type Params = DidSaveNotebookDocumentParams;
@@ -266,6 +283,7 @@ impl Notification for DidSaveNotebookDocument {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidCloseNotebookDocument {}
 impl Notification for DidCloseNotebookDocument {
     type Params = DidCloseNotebookDocumentParams;
@@ -277,6 +295,7 @@ impl Notification for DidCloseNotebookDocument {
 /// It is recommended that servers register for these file system events using the registration mechanism.
 /// In former implementations clients pushed file events without the server actively asking for it.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidChangeWatchedFiles {}
 
 impl Notification for DidChangeWatchedFiles {
@@ -287,6 +306,7 @@ impl Notification for DidChangeWatchedFiles {
 /// The workspace/didChangeWorkspaceFolders notification is sent from the client to the server to inform the server
 /// about workspace folder configuration changes
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidChangeWorkspaceFolders {}
 
 impl Notification for DidChangeWorkspaceFolders {
@@ -296,6 +316,7 @@ impl Notification for DidChangeWorkspaceFolders {
 
 /// Diagnostics notification are sent from the server to the client to signal results of validation runs.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum PublishDiagnostics {}
 
 impl Notification for PublishDiagnostics {
@@ -306,6 +327,7 @@ impl Notification for PublishDiagnostics {
 /// The progress notification is sent from the server to the client to ask
 /// the client to indicate progress.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Progress {}
 
 impl Notification for Progress {
@@ -316,6 +338,7 @@ impl Notification for Progress {
 /// The `window/workDoneProgress/cancel` notification is sent from the client
 /// to the server to cancel a progress initiated on the server side using the `window/workDoneProgress/create`.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkDoneProgressCancel {}
 
 impl Notification for WorkDoneProgressCancel {
@@ -325,6 +348,7 @@ impl Notification for WorkDoneProgressCancel {
 
 /// The did create files notification is sent from the client to the server when files were created from within the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidCreateFiles {}
 
 impl Notification for DidCreateFiles {
@@ -334,6 +358,7 @@ impl Notification for DidCreateFiles {
 
 /// The did rename files notification is sent from the client to the server when files were renamed from within the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidRenameFiles {}
 
 impl Notification for DidRenameFiles {
@@ -343,6 +368,7 @@ impl Notification for DidRenameFiles {
 
 /// The did delete files notification is sent from the client to the server when files were deleted from within the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DidDeleteFiles {}
 
 impl Notification for DidDeleteFiles {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -8,6 +8,7 @@ pub type ProgressToken = NumberOrString;
 /// the client to indicate progress.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ProgressParams {
     /// The progress token provided by the client.
     pub token: ProgressToken,
@@ -18,6 +19,7 @@ pub struct ProgressParams {
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ProgressParamsValue {
     WorkDone(WorkDoneProgress),
 }
@@ -26,6 +28,7 @@ pub enum ProgressParamsValue {
 /// from the server to the client to ask the client to create a work done progress.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressCreateParams {
     /// The token to be used to report progress.
     pub token: ProgressToken,
@@ -35,6 +38,7 @@ pub struct WorkDoneProgressCreateParams {
 /// to the server to cancel a progress initiated on the server side using the `window/workDoneProgress/create`.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressCancelParams {
     /// The token to be used to report progress.
     pub token: ProgressToken,
@@ -43,6 +47,7 @@ pub struct WorkDoneProgressCancelParams {
 /// Options to signal work done progress support in server capabilities.
 #[derive(Debug, Eq, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_progress: Option<bool>,
@@ -51,6 +56,7 @@ pub struct WorkDoneProgressOptions {
 /// An optional token that a server can use to report work done progress
 #[derive(Debug, Eq, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_token: Option<ProgressToken>,
@@ -58,6 +64,7 @@ pub struct WorkDoneProgressParams {
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressBegin {
     /// Mandatory title of the progress operation. Used to briefly inform
     /// about the kind of operation being performed.
@@ -90,6 +97,7 @@ pub struct WorkDoneProgressBegin {
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressReport {
     /// Controls if a cancel button should show to allow the user to cancel the
     /// long running operation. Clients that don't support cancellation are allowed
@@ -116,6 +124,7 @@ pub struct WorkDoneProgressReport {
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkDoneProgressEnd {
     /// Optional, more detailed associated progress message. Contains
     /// complementary information to the `title`.
@@ -127,6 +136,7 @@ pub struct WorkDoneProgressEnd {
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkDoneProgress {
     Begin(WorkDoneProgressBegin),
     Report(WorkDoneProgressReport),

--- a/src/references.rs
+++ b/src/references.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub type ReferenceClientCapabilities = DynamicRegistrationClientCapabilities;
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ReferenceContext {
     /// Include the declaration of the current symbol.
     pub include_declaration: bool,
@@ -14,6 +15,7 @@ pub struct ReferenceContext {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ReferenceParams {
     // Text Document and Position fields
     #[serde(flatten)]

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RenameParams {
     /// Text Document and Position fields
     #[serde(flatten)]
@@ -19,6 +20,7 @@ pub struct RenameParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RenameOptions {
     /// Renames should be checked and tested before being executed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,6 +32,7 @@ pub struct RenameOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct RenameClientCapabilities {
     /// Whether rename supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -63,6 +66,7 @@ pub struct RenameClientCapabilities {
 
 #[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct PrepareSupportDefaultBehavior(i32);
 lsp_enum! {
 impl PrepareSupportDefaultBehavior {
@@ -75,6 +79,7 @@ impl PrepareSupportDefaultBehavior {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum PrepareRenameResponse {
     Range(Range),
     RangeWithPlaceholder {

--- a/src/request.rs
+++ b/src/request.rs
@@ -215,6 +215,7 @@ macro_rules! lsp_request {
 /// * for a request the respond should be errored with `code: -32001`. The message can be picked by the server.
 /// * notifications should be dropped.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Initialize {}
 
 impl Request for Initialize {
@@ -227,6 +228,7 @@ impl Request for Initialize {
 /// but to not exit (otherwise the response might not be delivered correctly to the client).
 /// There is a separate exit notification that asks the server to exit.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Shutdown {}
 
 impl Request for Shutdown {
@@ -239,6 +241,7 @@ impl Request for Shutdown {
 /// in the user interface. In addition to the show message notification the request allows to pass actions and to
 /// wait for an answer from the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ShowMessageRequest {}
 
 impl Request for ShowMessageRequest {
@@ -251,6 +254,7 @@ impl Request for ShowMessageRequest {
 /// on the client side. Not all clients need to support dynamic capability registration. A client opts in via the
 /// ClientCapabilities.GenericCapability property.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum RegisterCapability {}
 
 impl Request for RegisterCapability {
@@ -262,6 +266,7 @@ impl Request for RegisterCapability {
 /// The client/unregisterCapability request is sent from the server to the client to unregister a
 /// previously register capability.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum UnregisterCapability {}
 
 impl Request for UnregisterCapability {
@@ -281,6 +286,7 @@ impl Request for UnregisterCapability {
 /// However, properties that are needed for the initial sorting and filtering, like sortText, filterText, insertText,
 /// and textEdit must be provided in the textDocument/completion request and must not be changed during resolve.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Completion {}
 
 impl Request for Completion {
@@ -291,6 +297,7 @@ impl Request for Completion {
 
 /// The request is sent from the client to the server to resolve additional information for a given completion item.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ResolveCompletionItem {}
 
 impl Request for ResolveCompletionItem {
@@ -302,6 +309,7 @@ impl Request for ResolveCompletionItem {
 /// The hover request is sent from the client to the server to request hover information at a given text
 /// document position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum HoverRequest {}
 
 impl Request for HoverRequest {
@@ -313,6 +321,7 @@ impl Request for HoverRequest {
 /// The signature help request is sent from the client to the server to request signature information at
 /// a given cursor position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SignatureHelpRequest {}
 
 impl Request for SignatureHelpRequest {
@@ -322,6 +331,7 @@ impl Request for SignatureHelpRequest {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum GotoDeclaration {}
 pub type GotoDeclarationParams = GotoDefinitionParams;
 pub type GotoDeclarationResponse = GotoDefinitionResponse;
@@ -337,6 +347,7 @@ impl Request for GotoDeclaration {
 /// The goto definition request is sent from the client to the server to resolve the definition location of
 /// a symbol at a given text document position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum GotoDefinition {}
 
 impl Request for GotoDefinition {
@@ -348,6 +359,7 @@ impl Request for GotoDefinition {
 /// The references request is sent from the client to the server to resolve project-wide references for the
 /// symbol denoted by the given text document position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum References {}
 
 impl Request for References {
@@ -360,6 +372,7 @@ impl Request for References {
 /// server to resolve the type definition location of a symbol at a
 /// given text document position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum GotoTypeDefinition {}
 
 pub type GotoTypeDefinitionParams = GotoDefinitionParams;
@@ -375,6 +388,7 @@ impl Request for GotoTypeDefinition {
 /// server to resolve the implementation location of a symbol at a
 /// given text document position.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum GotoImplementation {}
 
 pub type GotoImplementationParams = GotoTypeDefinitionParams;
@@ -394,6 +408,7 @@ impl Request for GotoImplementation {
 /// Symbol matches usually have a DocumentHighlightKind of Read or Write whereas fuzzy or textual matches
 /// use Text as the kind.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentHighlightRequest {}
 
 impl Request for DocumentHighlightRequest {
@@ -405,6 +420,7 @@ impl Request for DocumentHighlightRequest {
 /// The document symbol request is sent from the client to the server to list all symbols found in a given
 /// text document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentSymbolRequest {}
 
 impl Request for DocumentSymbolRequest {
@@ -416,6 +432,7 @@ impl Request for DocumentSymbolRequest {
 /// The workspace symbol request is sent from the client to the server to list project-wide symbols
 /// matching the query string.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceSymbolRequest {}
 
 impl Request for WorkspaceSymbolRequest {
@@ -427,6 +444,7 @@ impl Request for WorkspaceSymbolRequest {
 /// The `workspaceSymbol/resolve` request is sent from the client to the server to resolve
 /// additional information for a given workspace symbol.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceSymbolResolve {}
 
 impl Request for WorkspaceSymbolResolve {
@@ -439,6 +457,7 @@ impl Request for WorkspaceSymbolResolve {
 /// In most cases the server creates a WorkspaceEdit structure and applies the changes to the workspace using the request
 /// workspace/applyEdit which is sent from the server to the client.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ExecuteCommand {}
 
 impl Request for ExecuteCommand {
@@ -453,6 +472,7 @@ impl Request for ExecuteCommand {
 /// edits took too long or if a server constantly fails on this request. This is done to keep the
 /// save fast and reliable.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WillSaveWaitUntil {}
 
 impl Request for WillSaveWaitUntil {
@@ -464,6 +484,7 @@ impl Request for WillSaveWaitUntil {
 /// The workspace/applyEdit request is sent from the server to the client to modify resource on the
 /// client side.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ApplyWorkspaceEdit {}
 
 impl Request for ApplyWorkspaceEdit {
@@ -486,6 +507,7 @@ impl Request for ApplyWorkspaceEdit {
 /// settings the configuration should be returned for the passed resource URI. If the client can’t provide a
 /// configuration setting for a given scope then null need to be present in the returned array.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceConfiguration {}
 
 impl Request for WorkspaceConfiguration {
@@ -498,6 +520,7 @@ impl Request for WorkspaceConfiguration {
 /// and range. The request is triggered when the user moves the cursor into a problem marker in the editor or
 /// presses the lightbulb associated with a marker.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeActionRequest {}
 
 impl Request for CodeActionRequest {
@@ -512,6 +535,7 @@ impl Request for CodeActionRequest {
 ///
 /// @since 3.16.0
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeActionResolveRequest {}
 
 impl Request for CodeActionResolveRequest {
@@ -522,6 +546,7 @@ impl Request for CodeActionResolveRequest {
 
 /// The code lens request is sent from the client to the server to compute code lenses for a given text document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeLensRequest {}
 
 impl Request for CodeLensRequest {
@@ -533,6 +558,7 @@ impl Request for CodeLensRequest {
 /// The code lens resolve request is sent from the client to the server to resolve the command for a
 /// given code lens item.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeLensResolve {}
 
 impl Request for CodeLensResolve {
@@ -543,6 +569,7 @@ impl Request for CodeLensResolve {
 
 /// The document links request is sent from the client to the server to request the location of links in a document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentLinkRequest {}
 
 impl Request for DocumentLinkRequest {
@@ -554,6 +581,7 @@ impl Request for DocumentLinkRequest {
 /// The document link resolve request is sent from the client to the server to resolve the target of
 /// a given document link.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentLinkResolve {}
 
 impl Request for DocumentLinkResolve {
@@ -564,6 +592,7 @@ impl Request for DocumentLinkResolve {
 
 /// The document formatting request is sent from the server to the client to format a whole document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Formatting {}
 
 impl Request for Formatting {
@@ -574,6 +603,7 @@ impl Request for Formatting {
 
 /// The document range formatting request is sent from the client to the server to format a given range in a document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum RangeFormatting {}
 
 impl Request for RangeFormatting {
@@ -585,6 +615,7 @@ impl Request for RangeFormatting {
 /// The document on type formatting request is sent from the client to the server to format parts of
 /// the document during typing.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum OnTypeFormatting {}
 
 impl Request for OnTypeFormatting {
@@ -599,6 +630,7 @@ impl Request for OnTypeFormatting {
 /// to all other ranges if the new content is valid. If no result-specific word pattern is provided, the word pattern from
 /// the client’s language configuration is used.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum LinkedEditingRange {}
 
 impl Request for LinkedEditingRange {
@@ -609,6 +641,7 @@ impl Request for LinkedEditingRange {
 
 /// The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum Rename {}
 
 impl Request for Rename {
@@ -620,6 +653,7 @@ impl Request for Rename {
 /// The document color request is sent from the client to the server to list all color references found in a given text document.
 /// Along with the range, a color value in RGB is returned.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentColor {}
 
 impl Request for DocumentColor {
@@ -631,6 +665,7 @@ impl Request for DocumentColor {
 /// The color presentation request is sent from the client to the server to obtain a list of presentations for a color value
 /// at a given location.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ColorPresentationRequest {}
 
 impl Request for ColorPresentationRequest {
@@ -641,6 +676,7 @@ impl Request for ColorPresentationRequest {
 
 /// The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum FoldingRangeRequest {}
 
 impl Request for FoldingRangeRequest {
@@ -652,6 +688,7 @@ impl Request for FoldingRangeRequest {
 /// The prepare rename request is sent from the client to the server to setup and test the validity of a rename operation
 /// at a given location.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum PrepareRenameRequest {}
 
 impl Request for PrepareRenameRequest {
@@ -662,6 +699,7 @@ impl Request for PrepareRenameRequest {
 
 #[derive(Debug)]
 #[cfg(feature = "proposed")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineCompletionRequest {}
 
 #[cfg(feature = "proposed")]
@@ -675,6 +713,7 @@ impl Request for InlineCompletionRequest {
 /// workspace folders. Returns null in the response if only a single file is open in the tool.
 /// Returns an empty array if a workspace is open but no folders are configured.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceFoldersRequest {}
 
 impl Request for WorkspaceFoldersRequest {
@@ -686,6 +725,7 @@ impl Request for WorkspaceFoldersRequest {
 /// The `window/workDoneProgress/create` request is sent from the server
 /// to the client to ask the client to create a work done progress.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkDoneProgressCreate {}
 
 impl Request for WorkDoneProgressCreate {
@@ -703,6 +743,7 @@ impl Request for WorkDoneProgressCreate {
 ///
 /// Typically, but not necessary, selection ranges correspond to the nodes of the
 /// syntax tree.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SelectionRangeRequest {}
 
 impl Request for SelectionRangeRequest {
@@ -711,6 +752,7 @@ impl Request for SelectionRangeRequest {
     const METHOD: &'static str = "textDocument/selectionRange";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CallHierarchyPrepare {}
 
 impl Request for CallHierarchyPrepare {
@@ -719,6 +761,7 @@ impl Request for CallHierarchyPrepare {
     const METHOD: &'static str = "textDocument/prepareCallHierarchy";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CallHierarchyIncomingCalls {}
 
 impl Request for CallHierarchyIncomingCalls {
@@ -727,6 +770,7 @@ impl Request for CallHierarchyIncomingCalls {
     const METHOD: &'static str = "callHierarchy/incomingCalls";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CallHierarchyOutgoingCalls {}
 
 impl Request for CallHierarchyOutgoingCalls {
@@ -735,6 +779,7 @@ impl Request for CallHierarchyOutgoingCalls {
     const METHOD: &'static str = "callHierarchy/outgoingCalls";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensFullRequest {}
 
 impl Request for SemanticTokensFullRequest {
@@ -743,6 +788,7 @@ impl Request for SemanticTokensFullRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensFullDeltaRequest {}
 
 impl Request for SemanticTokensFullDeltaRequest {
@@ -751,6 +797,7 @@ impl Request for SemanticTokensFullDeltaRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full/delta";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensRangeRequest {}
 
 impl Request for SemanticTokensRangeRequest {
@@ -764,6 +811,7 @@ impl Request for SemanticTokensRangeRequest {
 /// As a result the client should ask the server to recompute the semantic tokens for these editors.
 /// This is useful if a server detects a project wide configuration change which requires a re-calculation of all semantic tokens.
 /// Note that the client still has the freedom to delay the re-calculation of the semantic tokens if for example an editor is currently not visible.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensRefresh {}
 
 impl Request for SemanticTokensRefresh {
@@ -777,6 +825,7 @@ impl Request for SemanticTokensRefresh {
 /// As a result the client should ask the server to recompute the code lenses for these editors.
 /// This is useful if a server detects a configuration change which requires a re-calculation of all code lenses.
 /// Note that the client still has the freedom to delay the re-calculation of the code lenses if for example an editor is currently not visible.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum CodeLensRefresh {}
 
 impl Request for CodeLensRefresh {
@@ -786,6 +835,7 @@ impl Request for CodeLensRefresh {
 }
 
 /// The will create files request is sent from the client to the server before files are actually created as long as the creation is triggered from within the client. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WillCreateFiles {}
 
 impl Request for WillCreateFiles {
@@ -795,6 +845,7 @@ impl Request for WillCreateFiles {
 }
 
 /// The will rename files request is sent from the client to the server before files are actually renamed as long as the rename is triggered from within the client. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WillRenameFiles {}
 
 impl Request for WillRenameFiles {
@@ -804,6 +855,7 @@ impl Request for WillRenameFiles {
 }
 
 /// The will delete files request is sent from the client to the server before files are actually deleted as long as the deletion is triggered from within the client. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WillDeleteFiles {}
 
 impl Request for WillDeleteFiles {
@@ -813,6 +865,7 @@ impl Request for WillDeleteFiles {
 }
 
 /// The show document request is sent from a server to a client to ask the client to display a particular document in the user interface.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ShowDocument {}
 
 impl Request for ShowDocument {
@@ -821,6 +874,7 @@ impl Request for ShowDocument {
     const METHOD: &'static str = "window/showDocument";
 }
 
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum MonikerRequest {}
 
 impl Request for MonikerRequest {
@@ -831,6 +885,7 @@ impl Request for MonikerRequest {
 
 /// The inlay hints request is sent from the client to the server to compute inlay hints for a given
 /// [text document, range] tuple that may be rendered in the editor in place with other text.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintRequest {}
 
 impl Request for InlayHintRequest {
@@ -843,6 +898,7 @@ impl Request for InlayHintRequest {
 /// information for a given inlay hint. This is usually used to compute the tooltip, location or
 /// command properties of a inlay hint’s label part to avoid its unnecessary computation during the
 /// `textDocument/inlayHint` request.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintResolveRequest {}
 
 impl Request for InlayHintResolveRequest {
@@ -857,6 +913,7 @@ impl Request for InlayHintResolveRequest {
 /// detects a configuration change which requires a re-calculation of all inlay hints. Note that the
 /// client still has the freedom to delay the re-calculation of the inlay hints if for example an
 /// editor is currently not visible.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlayHintRefreshRequest {}
 
 impl Request for InlayHintRefreshRequest {
@@ -867,6 +924,7 @@ impl Request for InlayHintRefreshRequest {
 
 /// The inline value request is sent from the client to the server to compute inline values for a
 /// given text document that may be rendered in the editor at the end of lines.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineValueRequest {}
 
 impl Request for InlineValueRequest {
@@ -881,6 +939,7 @@ impl Request for InlineValueRequest {
 /// a server detects a configuration change which requires a re-calculation of all inline values.
 /// Note that the client still has the freedom to delay the re-calculation of the inline values if
 /// for example an editor is currently not visible.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum InlineValueRefreshRequest {}
 
 impl Request for InlineValueRefreshRequest {
@@ -893,6 +952,7 @@ impl Request for InlineValueRefreshRequest {
 /// compute the diagnostics for a given document. As with other pull requests the server is asked
 /// to compute the diagnostics for the currently synced version of the document.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum DocumentDiagnosticRequest {}
 
 impl Request for DocumentDiagnosticRequest {
@@ -908,6 +968,7 @@ impl Request for DocumentDiagnosticRequest {
 /// workspace diagnostic pull it is legal to provide a document diagnostic report multiple times
 /// for the same document URI. The last one reported will win over previous reports.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceDiagnosticRequest {}
 
 impl Request for WorkspaceDiagnosticRequest {
@@ -921,6 +982,7 @@ impl Request for WorkspaceDiagnosticRequest {
 /// if a server detects a project wide configuration change which requires a re-calculation of all
 /// diagnostics.
 #[derive(Debug)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceDiagnosticRefresh {}
 
 impl Request for WorkspaceDiagnosticRefresh {
@@ -935,6 +997,7 @@ impl Request for WorkspaceDiagnosticRefresh {
 ///
 /// 1. first a type hierarchy item is prepared for the given text document position.
 /// 2. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum TypeHierarchyPrepare {}
 
 impl Request for TypeHierarchyPrepare {
@@ -948,6 +1011,7 @@ impl Request for TypeHierarchyPrepare {
 /// valid type from item in the params. The request doesn’t define its own client and server
 /// capabilities. It is only issued if a server registers for the
 /// `textDocument/prepareTypeHierarchy` request.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum TypeHierarchySupertypes {}
 
 impl Request for TypeHierarchySupertypes {
@@ -960,6 +1024,7 @@ impl Request for TypeHierarchySupertypes {
 /// subtypes for a given type hierarchy item. Will return null if the server couldn’t infer a valid
 /// type from item in the params. The request doesn’t define its own client and server capabilities.
 /// It is only issued if a server registers for the textDocument/prepareTypeHierarchy request.
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum TypeHierarchySubtypes {}
 
 impl Request for TypeHierarchySubtypes {

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectionRangeClientCapabilities {
     /// Whether implementation supports dynamic registration for selection range
     /// providers. If this is set to `true` the client supports the new
@@ -16,12 +17,14 @@ pub struct SelectionRangeClientCapabilities {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectionRangeOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectionRangeRegistrationOptions {
     #[serde(flatten)]
     pub selection_range_options: SelectionRangeOptions,
@@ -32,6 +35,7 @@ pub struct SelectionRangeRegistrationOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SelectionRangeProviderCapability {
     Simple(bool),
     Options(SelectionRangeOptions),
@@ -59,6 +63,7 @@ impl From<bool> for SelectionRangeProviderCapability {
 /// A parameter literal used in selection range requests.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectionRangeParams {
     /// The text document.
     pub text_document: TextDocumentIdentifier,
@@ -76,6 +81,7 @@ pub struct SelectionRangeParams {
 /// Represents a selection range.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SelectionRange {
     /// Range of the selection.
     pub range: Range,

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -12,7 +12,8 @@ use crate::{
 /// corresponding client capabilities.
 ///
 /// @since 3.16.0
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokenType(Cow<'static, str>);
 
 impl SemanticTokenType {
@@ -68,7 +69,8 @@ impl From<&'static str> for SemanticTokenType {
 /// corresponding client capabilities.
 ///
 /// @since 3.16.0
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokenModifier(Cow<'static, str>);
 
 impl SemanticTokenModifier {
@@ -104,7 +106,8 @@ impl From<&'static str> for SemanticTokenModifier {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TokenFormat(Cow<'static, str>);
 
 impl TokenFormat {
@@ -134,6 +137,7 @@ impl From<&'static str> for TokenFormat {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensLegend {
     /// The token types a server uses.
     pub token_types: Vec<SemanticTokenType>,
@@ -144,6 +148,7 @@ pub struct SemanticTokensLegend {
 
 /// The actual tokens.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticToken {
     pub delta_line: u32,
     pub delta_start: u32,
@@ -231,6 +236,7 @@ impl SemanticToken {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokens {
     /// An optional result id. If provided and clients support delta updating
     /// the client will include the result id in the next semantic token request.
@@ -252,6 +258,7 @@ pub struct SemanticTokens {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensPartialResult {
     #[serde(
         deserialize_with = "SemanticToken::deserialize_tokens",
@@ -263,6 +270,7 @@ pub struct SemanticTokensPartialResult {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensResult {
     Tokens(SemanticTokens),
     Partial(SemanticTokensPartialResult),
@@ -283,6 +291,7 @@ impl From<SemanticTokensPartialResult> for SemanticTokensResult {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensEdit {
     pub start: u32,
     pub delete_count: u32,
@@ -299,6 +308,7 @@ pub struct SemanticTokensEdit {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensFullDeltaResult {
     Tokens(SemanticTokens),
     TokensDelta(SemanticTokensDelta),
@@ -320,6 +330,7 @@ impl From<SemanticTokensDelta> for SemanticTokensFullDeltaResult {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_id: Option<String>,
@@ -333,6 +344,7 @@ pub struct SemanticTokensDelta {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensClientCapabilities {
     /// Whether implementation supports dynamic registration. If this is set to `true`
     /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
@@ -392,6 +404,7 @@ pub struct SemanticTokensClientCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensClientCapabilitiesRequests {
     /// The client will send the `textDocument/semanticTokens/range` request if the server provides a corresponding handler.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -405,6 +418,7 @@ pub struct SemanticTokensClientCapabilitiesRequests {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensFullOptions {
     Bool(bool),
     Delta {
@@ -418,6 +432,7 @@ pub enum SemanticTokensFullOptions {
 /// @since 3.16.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
@@ -437,6 +452,7 @@ pub struct SemanticTokensOptions {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -451,6 +467,7 @@ pub struct SemanticTokensRegistrationOptions {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensServerCapabilities {
     SemanticTokensOptions(SemanticTokensOptions),
     SemanticTokensRegistrationOptions(SemanticTokensRegistrationOptions),
@@ -470,6 +487,7 @@ impl From<SemanticTokensRegistrationOptions> for SemanticTokensServerCapabilitie
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensWorkspaceClientCapabilities {
     /// Whether the client implementation supports a refresh request sent from
     /// the server to the client.
@@ -483,6 +501,7 @@ pub struct SemanticTokensWorkspaceClientCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -496,6 +515,7 @@ pub struct SemanticTokensParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensDeltaParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -513,6 +533,7 @@ pub struct SemanticTokensDeltaParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SemanticTokensRangeParams {
     #[serde(flatten)]
     pub work_done_progress_params: WorkDoneProgressParams,
@@ -530,6 +551,7 @@ pub struct SemanticTokensRangeParams {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum SemanticTokensRangeResult {
     Tokens(SemanticTokens),
     Partial(SemanticTokensPartialResult),

--- a/src/signature_help.rs
+++ b/src/signature_help.rs
@@ -7,6 +7,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureInformationSettings {
     /// Client supports the follow content formats for the documentation
     /// property. The order describes the preferred format of the client.
@@ -26,6 +27,7 @@ pub struct SignatureInformationSettings {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ParameterInformationSettings {
     /// The client supports processing label offsets instead of a
     /// simple label string.
@@ -37,6 +39,7 @@ pub struct ParameterInformationSettings {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpClientCapabilities {
     /// Whether completion supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,6 +63,7 @@ pub struct SignatureHelpClientCapabilities {
 /// Signature help options.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpOptions {
     /// The characters that trigger signature help automatically.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,6 +81,7 @@ pub struct SignatureHelpOptions {
 
 /// Signature help options.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -85,6 +90,7 @@ pub struct SignatureHelpRegistrationOptions {
 /// Signature help options.
 #[derive(Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpTriggerKind(i32);
 lsp_enum! {
 impl SignatureHelpTriggerKind {
@@ -99,6 +105,7 @@ impl SignatureHelpTriggerKind {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpParams {
     /// The signature help context. This is only available if the client specifies
     /// to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
@@ -114,6 +121,7 @@ pub struct SignatureHelpParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelpContext {
     /// Action that caused signature help to be triggered.
     pub trigger_kind: SignatureHelpTriggerKind,
@@ -140,6 +148,7 @@ pub struct SignatureHelpContext {
 /// active and only one active parameter.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureHelp {
     /// One or more signatures.
     pub signatures: Vec<SignatureInformation>,
@@ -158,6 +167,7 @@ pub struct SignatureHelp {
 /// a set of parameters.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SignatureInformation {
     /// The label of this signature. Will be shown in
     /// the UI.
@@ -185,6 +195,7 @@ pub struct SignatureInformation {
 /// have a label and a doc-comment.
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ParameterInformation {
     /// The label of this parameter information.
     ///
@@ -201,6 +212,7 @@ pub struct ParameterInformation {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum ParameterLabel {
     Simple(String),
     LabelOffsets([u32; 2]),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct SetTraceParams {
     /// The new value that should be assigned to the trace setting.
     pub value: TraceValue,
@@ -13,6 +14,7 @@ pub struct SetTraceParams {
 /// later using the `SetTrace` notification.
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum TraceValue {
     /// The server should not send any `$/logTrace` notification
     #[default]
@@ -24,6 +26,7 @@ pub enum TraceValue {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LogTraceParams {
     /// The message to be logged.
     pub message: String,

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -9,12 +9,14 @@ use serde::{Deserialize, Serialize};
 pub type TypeHierarchyClientCapabilities = DynamicRegistrationClientCapabilities;
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchyOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchyRegistrationOptions {
     #[serde(flatten)]
     pub text_document_registration_options: TextDocumentRegistrationOptions,
@@ -25,6 +27,7 @@ pub struct TypeHierarchyRegistrationOptions {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchyPrepareParams {
     #[serde(flatten)]
     pub text_document_position_params: TextDocumentPositionParams,
@@ -33,6 +36,7 @@ pub struct TypeHierarchyPrepareParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchySupertypesParams {
     pub item: TypeHierarchyItem,
 
@@ -43,6 +47,7 @@ pub struct TypeHierarchySupertypesParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchySubtypesParams {
     pub item: TypeHierarchyItem,
 
@@ -54,6 +59,7 @@ pub struct TypeHierarchySubtypesParams {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct TypeHierarchyItem {
     /// The name of this item.
     pub name: String,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,13 +1,12 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use serde_json::Value;
 
-use crate::{Range, Uri};
+use crate::{Map, Range, Uri};
 
 #[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MessageType(i32);
 lsp_enum! {
 impl MessageType {
@@ -25,6 +24,7 @@ impl MessageType {
 /// Window specific client capabilities.
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WindowClientCapabilities {
     /// Whether client supports handling progress notifications. If set
     /// servers are allowed to report in `workDoneProgress` property in the
@@ -50,6 +50,7 @@ pub struct WindowClientCapabilities {
 /// Show message request client capabilities
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowMessageRequestClientCapabilities {
     /// Capabilities specific to the `MessageActionItem` type.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,6 +59,7 @@ pub struct ShowMessageRequestClientCapabilities {
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MessageActionItemCapabilities {
     /// Whether the client supports additional attributes which
     /// are preserved and send back to the server in the
@@ -68,6 +70,7 @@ pub struct MessageActionItemCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct MessageActionItem {
     /// A short title like 'Retry', 'Open Log' etc.
     pub title: String,
@@ -76,11 +79,12 @@ pub struct MessageActionItem {
     /// sends back to the server. This depends on the client
     /// capability window.messageActionItem.additionalPropertiesSupport
     #[serde(flatten)]
-    pub properties: HashMap<String, MessageActionItemProperty>,
+    pub properties: Map<String, MessageActionItemProperty>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum MessageActionItemProperty {
     String(String),
     Boolean(bool),
@@ -89,6 +93,7 @@ pub enum MessageActionItemProperty {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct LogMessageParams {
     /// The message type. See {@link MessageType}
     #[serde(rename = "type")]
@@ -99,6 +104,7 @@ pub struct LogMessageParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowMessageParams {
     /// The message type. See {@link MessageType}.
     #[serde(rename = "type")]
@@ -109,6 +115,7 @@ pub struct ShowMessageParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowMessageRequestParams {
     /// The message type. See {@link MessageType}
     #[serde(rename = "type")]
@@ -125,6 +132,7 @@ pub struct ShowMessageRequestParams {
 /// Client capabilities for the show document request.
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowDocumentClientCapabilities {
     /// The client has support for the show document request.
     pub support: bool,
@@ -135,6 +143,7 @@ pub struct ShowDocumentClientCapabilities {
 /// @since 3.16.0
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowDocumentParams {
     /// The document uri to show.
     pub uri: Uri,
@@ -165,6 +174,7 @@ pub struct ShowDocumentParams {
 /// @since 3.16.0
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct ShowDocumentResult {
     /// A boolean indicating if the show was successful.
     pub success: bool,

--- a/src/workspace_diagnostic.rs
+++ b/src/workspace_diagnostic.rs
@@ -10,6 +10,7 @@ use crate::{
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DiagnosticWorkspaceClientCapabilities {
     /// Whether the client implementation supports a refresh request sent from
     /// the server to the client.
@@ -26,6 +27,7 @@ pub struct DiagnosticWorkspaceClientCapabilities {
 ///
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct PreviousResultId {
     /// The URI for which the client knows a result ID.
     pub uri: Uri,
@@ -39,6 +41,7 @@ pub struct PreviousResultId {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceDiagnosticParams {
     /// The additional identifier provided during registration.
     pub identifier: Option<String>,
@@ -59,6 +62,7 @@ pub struct WorkspaceDiagnosticParams {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFullDocumentDiagnosticReport {
     /// The URI for which diagnostic information is reported.
     pub uri: Uri,
@@ -77,6 +81,7 @@ pub struct WorkspaceFullDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceUnchangedDocumentDiagnosticReport {
     /// The URI for which diagnostic information is reported.
     pub uri: Uri,
@@ -95,6 +100,7 @@ pub struct WorkspaceUnchangedDocumentDiagnosticReport {
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceDocumentDiagnosticReport {
     Full(WorkspaceFullDocumentDiagnosticReport),
     Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
@@ -116,6 +122,7 @@ impl From<WorkspaceUnchangedDocumentDiagnosticReport> for WorkspaceDocumentDiagn
 ///
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceDiagnosticReport {
     pub items: Vec<WorkspaceDocumentDiagnosticReport>,
 }
@@ -124,12 +131,14 @@ pub struct WorkspaceDiagnosticReport {
 ///
 /// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceDiagnosticReportPartialResult {
     pub items: Vec<WorkspaceDocumentDiagnosticReport>,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceDiagnosticReportResult {
     Report(WorkspaceDiagnosticReport),
     Partial(WorkspaceDiagnosticReportPartialResult),

--- a/src/workspace_folders.rs
+++ b/src/workspace_folders.rs
@@ -4,6 +4,7 @@ use crate::{OneOf, Uri};
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFoldersServerCapabilities {
     /// The server has support for workspace folders
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,6 +23,7 @@ pub struct WorkspaceFoldersServerCapabilities {
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFolder {
     /// The associated URI for this workspace folder.
     pub uri: Uri,
@@ -31,6 +33,7 @@ pub struct WorkspaceFolder {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct DidChangeWorkspaceFoldersParams {
     /// The actual workspace folder change event.
     pub event: WorkspaceFoldersChangeEvent,
@@ -39,6 +42,7 @@ pub struct DidChangeWorkspaceFoldersParams {
 /// The workspace folder change event.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceFoldersChangeEvent {
     /// The array of added workspace folders
     pub added: Vec<WorkspaceFolder>,

--- a/src/workspace_symbols.rs
+++ b/src/workspace_symbols.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceSymbolClientCapabilities {
     /// This capability supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,6 +39,7 @@ pub struct WorkspaceSymbolClientCapabilities {
 
 /// The parameters of a Workspace Symbol Request.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceSymbolParams {
     #[serde(flatten)]
     pub partial_result_params: PartialResultParams,
@@ -50,6 +52,7 @@ pub struct WorkspaceSymbolParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceSymbolResolveSupportCapability {
     /// The properties that a client can resolve lazily. Usually
     /// `location.range`
@@ -61,6 +64,7 @@ pub struct WorkspaceSymbolResolveSupportCapability {
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceSymbol {
     /// The name of this symbol.
     pub name: String,
@@ -93,12 +97,14 @@ pub struct WorkspaceSymbol {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub struct WorkspaceLocation {
     pub uri: Uri,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "hash", derive(Hash))]
 pub enum WorkspaceSymbolResponse {
     Flat(Vec<SymbolInformation>),
     Nested(Vec<WorkspaceSymbol>),


### PR DESCRIPTION
I made this an opt-in feature as in some data structures we are replacing `HashMap` with `OrderMap`.

Fix #245