### PR TITLE
fix: correctly deserialize `HoverContents` from 2-length array

### DIFF
--- a/src/hover.rs
+++ b/src/hover.rs
@@ -80,7 +80,7 @@ pub struct Hover {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HoverContents {
-    Scalar(MarkedString),
     Array(Vec<MarkedString>),
+    Scalar(MarkedString),
     Markup(MarkupContent),
 }


### PR DESCRIPTION
This fixes an issue where `Hover.contents` with an array of 2 strings gets deserialized into `HoverContents::Scalar(MarkedString::LanguageString { language: contents[0], value: contents[1] })` instead of `HoverContents::Array`.

Tested this change through Zed (it uses this package to ser-de LSP RPCs)

Before:
![스크린샷 2024-12-09 오후 10 24 39](https://github.com/user-attachments/assets/12327bbd-f1f7-4c8a-b9a2-7bf1f5c72a43)

After:
![스크린샷 2024-12-09 오후 10 19 11](https://github.com/user-attachments/assets/b85b2123-13c9-4aa5-95c5-0009882d00b4)
