### PR TITLE
Add missing type_hierarchy_provider field to ServerCapabilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1923,6 +1923,12 @@ pub struct ServerCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moniker_provider: Option<OneOf<bool, MonikerServerCapabilities>>,
 
+    /// The server provides type hierarchy support.
+	///
+	/// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+	pub type_hierarchy_provider: Option<OneOf<bool,TypeHierarchyServerCapabilities>>,
+
     /// The server provides linked editing range support.
     ///
     /// @since 3.16.0

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -8,6 +8,13 @@ use serde::{Deserialize, Serialize};
 
 pub type TypeHierarchyClientCapabilities = DynamicRegistrationClientCapabilities;
 
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TypeHierarchyServerCapabilities {
+    Options(TypeHierarchyOptions),
+    RegistrationOptions(TypeHierarchyRegistrationOptions),
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 pub struct TypeHierarchyOptions {
     #[serde(flatten)]


### PR DESCRIPTION
This pull requests adds the missing `type_hierarchy_provider` field to `ServerCapabilities`, as per the [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities) (since v3.17)